### PR TITLE
Deploy contracts as part of 'make build'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ radish34=./radish34
 # over time, as the radish34 use-case is abstracted/generalized into
 # the baseline protocol, the pushd/popd hacks will fade away...
 
-.PHONY: build clean contracts deploy-contracts npm-install start stop test zk-circuits
+.PHONY: build clean contracts deploy-contracts npm-install start stop rest test zk-circuits
 
 default: build
 
@@ -14,6 +14,7 @@ build: npm-install contracts
 	pushd ${radish34} && \
 	docker-compose build && \
 	npm run setup && \
+	npm run deploy && \
 	popd
 
 clean: stop
@@ -44,6 +45,12 @@ start:
 stop:
 	pushd ${radish34} && \
 	docker-compose down && \
+	popd
+
+reset:
+	pushd ${radish34} && \
+	docker-compose down && \
+	docker volume rm radish34_mongo-buyer radish34_mongo-supplier1 radish34_mongo-supplier2 radish34_mongo-merkle-tree-volume radish34_chaindata && \
 	popd
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ radish34=./radish34
 # over time, as the radish34 use-case is abstracted/generalized into
 # the baseline protocol, the pushd/popd hacks will fade away...
 
-.PHONY: build clean contracts deploy-contracts npm-install start stop rest test zk-circuits
+.PHONY: build clean contracts deploy-contracts npm-install start stop reset test zk-circuits
 
 default: build
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ build: npm-install contracts
 
 clean: stop
 	docker container prune -f
-	docker network prune -f
 	$(radish34)/../bin/clean_npm.sh
 
 contracts:
@@ -51,6 +50,8 @@ reset:
 	pushd ${radish34} && \
 	docker-compose down && \
 	docker volume rm radish34_mongo-buyer radish34_mongo-supplier1 radish34_mongo-supplier2 radish34_mongo-merkle-tree-volume radish34_chaindata && \
+	npm run deploy && \
+	docker-compose down && \
 	popd
 
 test:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here are the targets currently exposed by the `Makefile`:
 | `make npm-install` | `npm ci` wrapper for all modules in the monorepo. |
 | `make start` | Start the full __Baseline__ stack. Requires `docker` service to be running with at least 12 GB RAM allocation. |
 | `make stop` | Stop the running __Baseline__ stack. |
+| `make reset` | Clean the docker environment by pruning the docker networks and volumes. |
 | `make test` | Run the full test suite. Requires the stack to be running. |
 | `make zk-circuits` | Perform zk-SNARK trusted setups for circuits contained within `zkp/circuits` |
 


### PR DESCRIPTION
## Description

Fix the `make start` script so that it creates the config files and deploy the contracts before spinning up all containers.

## Related Issue

https://github.com/ethereum-oasis/baseline/issues/29

## Motivation and Context

Fix bug.

## How Has This Been Tested

- deleted my local `<repo_root>/radish34/config/config-*.json` files
- ran `make start`
- ran `make test`
- all tests pass