### PR TITLE
fix: babel build dist/ before starting services

### DIFF
--- a/radish34/api/.babelrc
+++ b/radish34/api/.babelrc
@@ -1,5 +1,18 @@
 {
   "presets": [
     "@babel/preset-env"
+  ],
+  "plugins": [
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "absoluteRuntime": false,
+        "corejs": false,
+        "helpers": true,
+        "regenerator": true,
+        "useESModules": false,
+        "version": "7.0.0-beta.0"
+      }
+    ]
   ]
 }

--- a/radish34/api/package.json
+++ b/radish34/api/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "start": "npm run build && node ./dist/index.js",
-    "dev": "nodemon --exec babel-node ./src/index.js",
+    "dev": "npm run build && nodemon --exec babel-node ./src/index.js",
     "fix": "npm run format && npm run lint -- --fix",
     "format": "prettier --write \"**/*.{json,css,scss,md}\"",
     "lint": "eslint .",

--- a/radish34/api/package.json
+++ b/radish34/api/package.json
@@ -58,6 +58,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/node": "^7.8.7",
+    "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "cod-scripts": "^3.2.0",
     "eslint": "^6.8.0",

--- a/radish34/zkp/.babelrc
+++ b/radish34/zkp/.babelrc
@@ -1,5 +1,18 @@
 {
   "presets": [
     "@babel/preset-env"
+  ],
+  "plugins": [
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "absoluteRuntime": false,
+        "corejs": false,
+        "helpers": true,
+        "regenerator": true,
+        "useESModules": false,
+        "version": "7.0.0-beta.0"
+      }
+    ]
   ]
 }

--- a/radish34/zkp/package.json
+++ b/radish34/zkp/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "start": "npm run build && node ./dist/index.js",
-    "dev": "nodemon --exec babel-node ./src/index.js",
+    "dev": "npm run build && nodemon --exec babel-node ./src/index.js",
     "test": "jest --watchAll --verbose=true --silent",
     "test:ci": "jest --verbose=true --silent --ci --coverage",
     "fix": "npm run format && npm run lint -- --fix",

--- a/radish34/zkp/package.json
+++ b/radish34/zkp/package.json
@@ -39,10 +39,11 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/node": "^7.8.7",
-    "cod-scripts": "^3.2.0",
+    "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
-    "markdownlint-cli": "^0.15.0",
+    "cod-scripts": "^3.2.0",
     "jest": "^24.9.0",
+    "markdownlint-cli": "^0.15.0",
     "nodemon": "^1.18.9"
   },
   "nodemonConfig": {


### PR DESCRIPTION
# Description

`zkp` and `api` services use babel as a transpiler. The services need to run `npm run build` to build the `dist/` directory before starting up. This PR fixes that bug

## How Has This Been Tested

- Deleted `zkp/dist/` and `api/dist/` directories
- Rebuilt those services: `docker-compose build api-buyer api-supplier1 api-supplier2 zkp`
- `make stop`
- `make reset`
- `make deploy-contracts`
- `make start`
- `make test`

All tests passed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
