### PR TITLE
fix: allow offline caching of sol compiler

### DIFF
--- a/radish34/contracts/compiler.json
+++ b/radish34/contracts/compiler.json
@@ -1,4 +1,6 @@
 {
   "contractsDir": "contracts",
-  "artifactsDir": "artifacts"
+  "artifactsDir": "artifacts",
+  "solcVersion": "0.5.8",
+  "isOfflineMode": true
 }


### PR DESCRIPTION
# Description

Updated compiler settings for `sol-compiler` service to build in offline mode

## Related Issue

#86 

## Motivation and Context

To allow for building of smart contract artifacts, using `sol-compiler`, when behind a proxy wall or weak connection.

## How Has This Been Tested

Remove local `contracts/artifacts/*`, disallow internet connection, and run `npm run build`.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
