### PR TITLE
Removed old manager param as it was misleading and not needed

### DIFF
--- a/radish34/.gitignore
+++ b/radish34/.gitignore
@@ -101,3 +101,4 @@ config/merkle-tree/
 
 # Ignore generated docs
 docs/generated
+.vscode

--- a/radish34/contracts/__tests__/OrgRegistry.test.js
+++ b/radish34/contracts/__tests__/OrgRegistry.test.js
@@ -102,7 +102,7 @@ test('Should be able to get registrar info', async () => {
 });
 
 test('Should be able to assign new manager', async () => {
-  await orgRegistry.assignManager(orgRegistry.address, accounts[0]);
+  await orgRegistry.assignManager(accounts[0]);
   const newManager = await erc1820Registry.getManager(orgRegistry.address);
   expect(newManager).toBe(accounts[0]);
 });

--- a/radish34/contracts/contracts/OrgRegistry.sol
+++ b/radish34/contracts/contracts/OrgRegistry.sol
@@ -100,8 +100,8 @@ contract OrgRegistry is Ownable, ERC165Compatible, Registrar, IOrgRegistry {
 
     /// @dev Since this is an inherited method from Registrar, it allows for a new manager to be set
     /// for this contract instance
-    function assignManager(address _oldManager, address _newManager) external {
-        assignManagement(_oldManager, _newManager);
+    function assignManager(address _newManager) external {
+        assignManagement(_newManager);
     }
 
     /// @notice Function to register an organization

--- a/radish34/contracts/contracts/Registrar.sol
+++ b/radish34/contracts/contracts/Registrar.sol
@@ -37,9 +37,8 @@ contract Registrar is ERC1820Registry {
     /// @dev This enables assigning or changing manager
     /// @notice Since this is an internal method any contract inheriting this contract would be
     /// leveraged to call this function directly
-    /// @param _oldManager address of the current manager who can set new interface implementations
     /// @param _newManager address of the new manager who could set new interface implementations
-    function assignManagement(address _oldManager, address _newManager) internal {
-        ERC1820REGISTRY.setManager(_oldManager, _newManager);
+    function assignManagement(address _newManager) internal {
+        ERC1820REGISTRY.setManager(address(this), _newManager);
     }
 }

--- a/radish34/contracts/contracts/Shield.sol
+++ b/radish34/contracts/contracts/Shield.sol
@@ -75,8 +75,8 @@ contract Shield is Ownable, MerkleTree, ERC165Compatible, Registrar, IShield {
         return ERC1820_ACCEPT_MAGIC;
     }
 
-    function assignManager(address _oldManager, address _newManager) external {
-        assignManagement(_oldManager, _newManager);
+    function assignManager(address _newManager) external {
+        assignManagement(_newManager);
     }
 
     /**

--- a/radish34/contracts/contracts/Verifier.sol
+++ b/radish34/contracts/contracts/Verifier.sol
@@ -71,8 +71,8 @@ contract Verifier is Ownable, ERC165Compatible, Registrar, IVerifier {
         return ERC1820_ACCEPT_MAGIC;
     }
 
-    function assignManager(address _oldManager, address _newManager) external {
-        assignManagement(_oldManager, _newManager);
+    function assignManager(address _newManager) external {
+        assignManagement(_newManager);
     }
 
     function verify(


### PR DESCRIPTION
# Description

Changed the Registrar contract to pass itself as address of the contract that is managed by the manager instead of passing it from the outside. Modified the tests

## Motivation and Context

The parameter was not needed and the param name and description were misleading. Minor Gas optimization also

## How Has This Been Tested

Unit tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
