### PR TITLE
Added maintainers and code of conduct drafts

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[op-admin@lists.oasis-open-projects.org](op-admin@lists.oasis-open-projects.org).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -40,7 +40,7 @@ All provisional maintainers must meet with the existing maintainers and demonstr
  - Explaining the components of the system architecture
  - Walking through the code and explain the baseline process
 
-Once the provisional maintainer demonstrates their capabilities they existing maintainers will vote during the next scheduled maintainer meeting to give the prospect full maintainer status. Members must vote with 2/3rds majority to add a new maintainer. Voting that results in a tie or potentially other issue will be brought to the TSC for review.
+Once the provisional maintainer demonstrates their capabilities, the existing maintainers will vote during the next scheduled maintainer meeting to give the prospect full maintainer status. Members must vote with 2/3rds majority to add a new maintainer. Voting that results in a tie or potentially other issue will be brought to the TSC for review.
 
 # What is expected of maintainers?
 
@@ -53,10 +53,8 @@ In general, a maintainer needs to:
  - follow the project style and testing guidelines
  - have a high degree of understanding of the project architecture
  - be welcoming to others in the community who are using the project
- - contribute in ways that substantially improve the quality of the project and the experience of people using it
- - follow good branch naming conventions: [good references here](https://gist.github.com/digitaljhelms/4287848)
- - Follow linting conventions for committing changes and by others
- - follow PR naming conventions
+ - contribute in ways that substantially improve the quality of the project and the experience of people who use it
+ - follow branch, PR, and code style conventions
 
 # How maintainers organize?
 
@@ -68,10 +66,10 @@ There are weekly *Maintainers meetings* where members can discuss plans and issu
 
 # How to stop being a maintainer?
 
-If you are a maintainer you loose maintainer status if any of the following occur: 
+Any of the following ways: 
 
  - You stop reviewing PR's, responding to messages, answering emails, and/or generally ghost the project.
- - You are disrespectful towards anyone in the community and/or involved in the project in some way.
+ - You are disrespectful towards anyone in the community and/or involved in the project.
  - You are disruptive to the general process of maintaining the project, meetings, discussions, issues, or other. 
  - You violate [the code of conduct](./CODE_OF_CONDUCT.md).
  - You notify the other maintainers you would like to relinquish your maintainer status.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,79 @@
+# What do maintainers do?
+
+Maintainers are people who take an active role in writing code that advances the Baseline Protocol and/or related projects (e.g. the Radish34 Demo). They are primarily responsible for:
+ - Contributing code to the project in the form of PRs that are linked to open and prioritized issues 
+ - Reviewing and merging PRs into the master branch
+ - Cutting, testing, and releasing new versions of the related Baseline projects
+ - Working with the TSC and SSC to advance the Baseline Protocol
+
+ They can/should also contribute in the following ways:
+ - Writing epics and issues to guide development
+ - Setting up and supporting infrastructure (running demos, CI systems, community projects, etc...) that further Baseline
+ - Working with the community to help with adoption
+ - Presenting the project and key technologies to the public (in-person, webinar, videos, articles, etc...)
+ 
+
+# Who are the current maintainers?
+
+Code and Systems maintainers
+  - [Sam Stokes](https://github.com/bitwiseguy) 
+  - [Patrick Macom](https://github.com/pmacom)
+  - [Kartheek Solipuram](https://github.com/skarred14)
+  - [Brian Chamberlain](https://github.com/breakpointer)
+  - [Kyle Thomas](https://github.com/kthomas)
+  - [Hudson Jameson](https://github.com/souptacular)
+
+Documentation maintainer/Technical Product Director
+
+  - [John](https://github.com/humbitious)
+
+
+# How to become a maintainer?
+
+There are two ways to become a maintainer: You are asked by a current maintainer, or you make request to an existing maintainer to become one.
+
+With either path you become a "provisional maintainer". As such you will need to show consistent contributions of code to the project. This can be in the form of pull requests that get merged into master. Or it can be in the form of system architecture and related artifacts that guide the development activities of others. 
+
+All provisional maintainers must meet with the existing maintainers and demonstrate they are capable of the following: 
+ - Running the project locally
+ - Using the testing framework
+ - Explaining the components of the system architecture
+ - Walking through the code and explain the baseline process
+
+Once the provisional maintainer demonstrates their capabilities they existing maintainers will vote during the next scheduled maintainer meeting to give the prospect full maintainer status. Members must vote with 2/3rds majority to add a new maintainer. Voting that results in a tie or potentially other issue will be brought to the TSC for review.
+
+# What is expected of maintainers?
+
+In general, a maintainer needs to:
+ - be an expert in one or more fields related to the project
+ - show commitment over time with multiple PRs merged
+ - be reliable in completing issues to which they have been assigned
+ - attend the weekly maintainer meetings (with occasional absences allowed)
+ - demonstrate competency in software development
+ - follow the project style and testing guidelines
+ - have a high degree of understanding of the project architecture
+ - be welcoming to others in the community who are using the project
+ - contribute in ways that substantially improve the quality of the project and the experience of people using it
+ - follow good branch naming conventions: [good references here](https://gist.github.com/digitaljhelms/4287848)
+ - Follow linting conventions for committing changes and by others
+ - follow PR naming conventions
+
+# How maintainers organize?
+
+## Slack 
+Maintainers meet and discuss issues virtually via the private #maintainers slack room in the [baseline slack](ethereum-baseline.slack.com). 
+
+## Weekly Meetings
+There are weekly *Maintainers meetings* where members can discuss plans and issues related to the project, updates, release planning, and other related topics. These meetings are not public but special exceptions can be granted for members of the baseline community, experts, or other key participants. The summaries of the meetings will be posted to the public #maintainer-meeting slack room.
+
+# How to stop being a maintainer?
+
+If you are a maintainer you loose maintainer status if any of the following occur: 
+
+ - You stop reviewing PR's, responding to messages, answering emails, and/or generally ghost the project.
+ - You are disrespectful towards anyone in the community and/or involved in the project in some way.
+ - You are disruptive to the general process of maintaining the project, meetings, discussions, issues, or other. 
+ - You violate [the code of conduct](./CODE_OF_CONDUCT.md).
+ - You notify the other maintainers you would like to relinquish your maintainer status.
+ 
+Two-thirds of all current maintainers constitute a quorum for a meeting involving a question of removal. A simple majority vote from maintainers attending the meeting is required to remove a maintainer, but the TSC may be brought in to arbitrate if the maintainer to be removed or any other maintainer wishes to dispute the action.


### PR DESCRIPTION
# Description

Added files to inform the community of the maintainer group in the Baseline project and also the projects code of conduct. 

## Motivation and Context

It solves the problem of people not knowing how to become maintainers, what maintainers do, and what is expected of someone with "maintainer" status. 

## Type of change
Documentation