### PR TITLE
Feature/makefile/for/ubuntu/system

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,15 @@ A `Makefile` has been included for convenience; most of its targets wrap `npm`, 
 
 Just want to get the __Baseline Protocol__ running locally? The following sequence will build the monorepo, start the __Baseline Protocol__ stack locally, deploy contracts and run the full test suite. *Note: this typically takes at least 20 minutes to complete.
 
+### On Mac
 ```
 make && make start && make test
+```
+
+### On Ubuntu
+
+```
+make -f UbuntuMakefile.mk && make start -f UbuntuMakefile.mk && make test -f UbuntuMakefile.mk
 ```
 
 ### The demo UI

--- a/UbuntuMakefile.mk
+++ b/UbuntuMakefile.mk
@@ -1,0 +1,100 @@
+# Makefile
+
+# relative path to the construction site
+radish34=./radish34
+
+# over time, as the radish34 use-case is abstracted/generalized into
+# the baseline protocol, the cd/cd .. hacks will fade away...
+
+.PHONY: build build-containers clean contracts deploy-contracts install-config npm-install start stop system-check reset restart test zk-circuits
+
+default: build
+
+build: npm-install contracts
+
+build-containers: build
+	cd ${radish34} && \
+	npm run dockerize:ubuntu && \
+	cd ..
+
+clean: stop
+	@$(radish34)/../bin/clean_npm.sh
+
+contracts:
+	cd ${radish34} && \
+	npm run build:contracts:ubuntu && \
+	cd ..
+
+deploy-contracts: install-config
+	cd ${radish34} && \
+	npm run deploy && \
+	cd ..
+
+install-config:
+	cd ${radish34} && \
+	npm run install-config && \
+	cd ..
+
+npm-install:
+	cd ${radish34} && \
+	npm run build:ubuntu && \
+	cd ..
+
+start: system-check install-config build-containers
+	cd ${radish34} && \
+	npm run setup-circuits && \
+	npm run deploy && \
+	docker-compose up -d api-buyer api-supplier1 api-supplier2 ui && \
+	cd ..
+
+stop:
+	cd ${radish34} && \
+	docker-compose down --remove-orphans && \
+	docker network rm \
+		radish34_network-buyer \
+		radish34_network-supplier1 \
+		radish34_network-supplier2 \
+		radish34_geth || true && \
+	docker volume rm radish34_mongo-merkle-tree-volume || true && \
+	cd ..
+
+system-check:
+	@npm run --silent system-check
+
+reset: stop
+	cd ${radish34} && \
+	docker container prune -f && \
+	docker volume rm \
+		radish34_mongo-buyer \
+		radish34_mongo-supplier1 \
+		radish34_mongo-supplier2 \
+		radish34_mongo-merkle-tree-volume \
+		radish34_chaindata || true && \
+	docker image rm \
+		radish34_api-buyer \
+		radish34_api-supplier1 \
+		radish34_api-supplier2 \
+		radish34_deploy \
+		radish34_messenger-buyer \
+		radish34_messenger-supplier1 \
+		radish34_messenger-supplier2 || true && \
+	rm -rf ./config && \
+	rm -rf ./zkp/output && \
+	cd ..
+
+restart: stop start
+
+test:
+	cd ${radish34} && \
+	npm run await-stack && \
+	npm run test && \
+	npm run postman-test-zkp-api && \
+	npm run postman-integration-test && \
+	cd ..
+
+zk-circuits:
+	cd ${radish34} && \
+	rm -rf ./zkp/output && \
+	mkdir -p ./zkp/output && \
+	npm run setup-circuits && \
+	cd ..

--- a/radish34/ops/ubuntu/build.sh
+++ b/radish34/ops/ubuntu/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+git diff --exit-code --quiet HEAD ./package.json && if [ $? -ne 0 ] || [[ ! -d ./node_modules ]]; then npm ci; fi
+
+./ops/ubuntu/build_api.sh
+./ops/ubuntu/build_contracts.sh
+./ops/ubuntu/build_deploy.sh
+./ops/ubuntu/build_messenger.sh
+./ops/ubuntu/build_ui.sh
+./ops/ubuntu/build_zkp.sh

--- a/radish34/ops/ubuntu/build_api.sh
+++ b/radish34/ops/ubuntu/build_api.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd api && git diff --exit-code --quiet HEAD . && if [ $? -ne 0 ] || [[ ! -d ./node_modules ]]; then npm ci; fi && cd ..

--- a/radish34/ops/ubuntu/build_contracts.sh
+++ b/radish34/ops/ubuntu/build_contracts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd contracts && git diff --exit-code --quiet HEAD . && if [ $? -ne 0 ] || [[ ! -d ./node_modules ]]; then npm ci; fi && cd ..

--- a/radish34/ops/ubuntu/build_deploy.sh
+++ b/radish34/ops/ubuntu/build_deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd deploy && git diff --exit-code --quiet HEAD . && if [ $? -ne 0 ] || [[ ! -d ./node_modules ]]; then npm ci; fi && cd ..

--- a/radish34/ops/ubuntu/build_messenger.sh
+++ b/radish34/ops/ubuntu/build_messenger.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd messenger && git diff --exit-code --quiet HEAD . && if [ $? -ne 0 ] || [[ ! -d ./node_modules ]]; then npm ci; fi && cd ..

--- a/radish34/ops/ubuntu/build_ui.sh
+++ b/radish34/ops/ubuntu/build_ui.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd ui && git diff --exit-code --quiet HEAD . && if [ $? -ne 0 ] || [[ ! -d ./node_modules ]]; then npm ci; fi && cd ..

--- a/radish34/ops/ubuntu/build_zkp.sh
+++ b/radish34/ops/ubuntu/build_zkp.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd zkp && git diff --exit-code --quiet HEAD . && if [ $? -ne 0 ] || [[ ! -d ./node_modules ]]; then npm ci; fi && cd ..

--- a/radish34/ops/ubuntu/dockerize.sh
+++ b/radish34/ops/ubuntu/dockerize.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# party-agnostic
+docker-compose build ganache geth-bootnode geth-node geth-miner1 geth-miner2
+
+# party-specific, external dependencies
+docker-compose build mongo-buyer mongo-supplier1 mongo-supplier2 redis-buyer redis-supplier1 redis-supplier2
+
+git diff --exit-code --quiet HEAD ./api && if [ $? -ne 0 ] || [[ ! -d ./api/node_modules ]]; then docker-compose build --no-cache api-buyer api-supplier1 api-supplier2; fi
+git diff --exit-code --quiet HEAD ./deploy && if [ $? -ne 0 ] || [[ ! -d ./deploy/node_modules ]]; then docker-compose build --no-cache deploy; fi
+git diff --exit-code --quiet HEAD ./messenger && if [ $? -ne 0 ] || [[ ! -d ./messenger/node_modules ]]; then docker-compose build --no-cache messenger-buyer messenger-supplier1 messenger-supplier2; fi
+git diff --exit-code --quiet HEAD ./ui && if [ $? -ne 0 ] || [[ ! -d ./ui/node_modules ]]; then docker-compose build --no-cache ui; fi
+git diff --exit-code --quiet HEAD ./zkp && if [ $? -ne 0 ] || [[ ! -d ./zkp/node_modules ]]; then docker-compose build --no-cache zkp; fi

--- a/radish34/ops/ubuntu/setup_circuits.sh
+++ b/radish34/ops/ubuntu/setup_circuits.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+docker-compose up --no-recreate -d zkp
+./ops/await_tcp.sh -t 30 -h localhost -p 8080
+
+if [ ! -d ./zkp/output/createMSA ]; then
+    sleep 5
+
+    printf "\n${GREEN}*** Running setup for createMSA ***${NC}\n"
+    curl -d '{"filepath": "business-logic/createMSA.zok"}' -H "Content-Type: application/json" -X POST http://localhost:8080/generate-keys
+    printf "\n${GREEN}*** createMSA setup complete ***${NC}\n"
+fi
+
+if [ ! -d ./zkp/output/createPO ]; then
+    sleep 5
+
+    printf "\n${GREEN}*** Running setup for createPO ***${NC}\n"
+    curl -d '{"filepath": "business-logic/createPO.zok"}' -H "Content-Type: application/json" -X POST http://localhost:8080/generate-keys
+    printf "\n${GREEN}*** createPO setup complete ***${NC}\n"
+fi

--- a/radish34/package.json
+++ b/radish34/package.json
@@ -27,10 +27,13 @@
   "scripts": {
     "await-stack": "./ops/await_stack.sh",
     "build": "./ops/build.sh",
+    "build:ubuntu": "./ops/ubuntu/build.sh",
     "build:contracts": "pushd contracts && npm run build && popd",
+    "build:contracts:ubuntu": "cd contracts && npm run build && cd ..",
     "deploy": "docker-compose run --rm deploy && docker-compose restart merkle-tree api-buyer api-supplier1 api-supplier2 || true",
     "docs:build": "./ops/build_docs.sh",
     "dockerize": "./ops/dockerize.sh",
+    "dockerize:ubuntu": "./ops/ubuntu/dockerize.sh",
     "install-config": "mkdir -p ./config && cp -r ./deploy/src/config/backups/* ./config && cp -r ./deploy/src/config/keystore ./config",
     "lint": "solhint \"contracts/**/*.sol\"",
     "postman-test-zkp-api": "npx newman run zkp/src/test/zkp-api-integration-test.postman_collection.json -e zkp/src/test/radish-local.postman_environment.json",


### PR DESCRIPTION
# Description

To run baseline locally, the command in place is `make && make start && make test`, this, in turn, invoked bash scripts under `radish34/ops/*.sh` via the Makefile.
Right from the Makefile to the bash scripts under `radish34/ops/*.sh`  `pushd & popd` are being used however on Ubuntu systems these are not valid commands the bash reports error for **pushd & popd**
Running Baseline locally on Ubuntu should be as easy as it is to execute on the Mac system, therefore made the required changes and created this PR.

## Related Issue

**None**

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When it comes to Mac running Baseline locally is as good as executing `make && make start && make test`, why not the same on Ubuntu systems?

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

By executing:

`make -f UbuntuMakefile.mk && make start -f UbuntuMakefile.mk && make test -f UbuntuMakele.mk`

OS: Ubuntu 18.04
Node: 11.15.0 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

- Replaced `-dir` with `-d` in bash scripts, as `-dir` was causing the if statements in bash scripts to stop from executing

    - Since `-dir` was failing the bash scripts thus created `ubuntu` under `ops` directory and moved the required bash scripts inside `ops/ubuntu` from `ops`.

- Replaced `pushd & popd` with `cd & cd..` in Makefile and in bash scripts wherever applicable

- Added a new Makefile for Ubuntu namely `UbuntuMakefile.mk`

- Updated README, added a command for running Baseline locally on Ubuntu system, the command is `make -f UbuntuMakefile.mk && make start -f UbuntuMakefile.mk && make test -f UbuntuMakefile.mk`

 ## Checklist

- Executed the above command on my system, the make command executed successfully.

## Note:

- Instead of having different bash scripts for Ubuntu and Mac, I tried adding If-else in the existing bash scripts, however, that was again resulting into the error generated by `-dir`, thus, created different directory altogether for bash scripts for Ubuntu and replaced `-dir` with `-d`

I hope it helps.
