### PR TITLE
Fix TSC election date

### DIFF
--- a/docs/community/community-members.md
+++ b/docs/community/community-members.md
@@ -4,7 +4,7 @@ Over 400 people and companies signed up to be notified about the opening of the 
 
 ### Bootstrapping Phase and Ongoing Phase
 
-The technical steering committee and the chair listed below will be seated provisionally for six months, from From March 19, 2020 to September 31, 2020. This bootstrapping period will end when the active contributors to the repo \(anyone who has submitted a pull request that was merged to master in the preceeding period\) vote on the new TSC and chair. The specifications steering committee \(SSC\) has a variable number, and membership is based on
+The technical steering committee and the chair listed below will be seated provisionally for six months, from From March 19, 2020 to September 30, 2020. This bootstrapping period will end when the active contributors to the repo \(anyone who has submitted a pull request that was merged to master in the preceeding period\) vote on the new TSC and chair. The specifications steering committee \(SSC\) has a variable number, and membership is based on
 
 The people and companies listed below have stepped up to identify themselves as supporters, stakeholders, responsible parties, and accountable parties to help bootstrap the Baseline Protocol work.
 

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -38,7 +38,7 @@ A TSC member is eligible to lose their seat upon missing two consecutive TSC mee
 
 In all cases \(7, 9 or 11 member TSC\), the original three organizations \(EY, MSFT, ConsenSys\) hold less than 50% of the seats, during the initial six month bootstrapping period.
 
-One TSC Member shall serve as provisional chair of the TSC for six months. On September 31, 2020, all members and the chair shall be open for new elections. Members of the community shall have voting rights based on contribution \(see below\):  
+One TSC Member shall serve as provisional chair of the TSC for six months. On September 30, 2020, all members and the chair shall be open for new elections. Members of the community shall have voting rights based on contribution \(see below\):
 
 
 #### Steady State Periods: 


### PR DESCRIPTION


# Description

The documentation suggests the TSC members will serve until
Sep 31, 2020, which is a date that doesn't exist.

Presumably, that was supposed to be September 30 (the last day of September)

This commit updates the documentation accordingly.

## Related Issue

There is no existing issue. I hope that's okay in this case because of how minor the suggestion is.

## Motivation and Context

N/A

## How Has This Been Tested

N/A

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
