### PR TITLE
Add windows 10 setup instructions for radish34 quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ In order to demonstrate the __Baseline Protocol__, we needed a use-case. The use
 The __Baseline Protocol__ code is currently embedded inside the `/radish-api` directory, but we are in the process of moving that code into the `/baseline` directory to clearly distinguish the protocol from the use-case. Once this move is complete, `radish-api` will import `baseline` as a module, which will be the same process that other projects will need to follow to implement __Baseline__.
 
 ## Quickstart
-
 A `Makefile` has been included for convenience; most of its targets wrap `npm`, `docker` and `solc` invocations.
+
+Windows 10 users [should follow some initial setup instructions](windows_setup.md) first.
 
 Just want to get the __Baseline Protocol__ running locally? The following sequence will build the monorepo, start the __Baseline Protocol__ stack locally, deploy contracts and run the full test suite. *Note: this typically takes at least 20 minutes to complete.
 

--- a/windows_setup.md
+++ b/windows_setup.md
@@ -1,0 +1,76 @@
+# Initial Setup for Windows 10 Users
+On Windows 10, the recommendation is to use the Windows Subsystem for Linux (WSL). For many Windows users, WSL may be unfamaliar. To setup WSL and install the prerequisite software, follow these steps:
+
+## 1) Setup WSL
+The latest version of WSL is also known as WSL2. Setup WSL2 following the guide here: https://docs.microsoft.com/en-us/windows/wsl/install-win10. Pick **Ubuntu** as the chosen distro.
+
+After installing Ubuntu, note the version number:
+```
+$ lsb_release -a
+Release:        20.04
+```
+You will use this version number to tailor further install instructions later on.
+
+## 2) Clone Baseline GitHub Repo
+On the GitHub website, fork the repo `https://github.com/ethereum-oasis/baseline` into your own account. Then clone the fork you just made:
+```
+$ cd /home/(your ubuntu username)
+$ git clone https://github.com/(your github username)/baseline.git
+```
+
+## 3) Install Node.js and npm
+Follow these instructions to install Node.js and npm. Notice that near the top of the instructions there is a dropdown and you can pick your exact Ubuntu version. For Ubuntu version `20.04` (the version you collected in step 1) the URL is this:
+
+https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-20-04
+
+## 4) Install Docker
+Follow these instructions to install Docker:
+https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-20-04.
+
+There are version-specific instructions available in the same way as the previous step. Note that in these instructions the command `sudo systemctl start docker` will not work, [because WSL2 does not support systemctl](https://github.com/MicrosoftDocs/WSL/issues/457#issuecomment-511495846).
+
+Instead of using `sudo systemctl start docker` use `sudo /etc/init.d/docker start`. Similarly you can check Docker status with:
+```
+$ sudo /etc/init.d/docker status
+* Docker is running
+```
+
+## 5) Add User to the Docker Group
+You must add your username to the docker group like this:
+```
+$ sudo usermod -aG docker (your ubuntu username)
+$ su - (your ubuntu username)
+```
+Check that it has worked like this, you should see the group `docker` in the list:
+```
+$ id -nG
+adm plugdev netdev docker
+```
+IF you don't do this step, you will get errors during Quickstart saying that docker is not available.
+
+## 6) Install docker-compose
+Follow instructions here, with version-specific variants available as before:
+https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-compose-on-ubuntu-20-04
+
+## 7) Ready for Quickstart!
+You can now return to the [Quickstart instructions](README.md#quickstart).
+
+If you are new to WSL there are some additional commands you may find handy:
+
+#### Managing WSL
+Start Powershell (not Powershell x86)  as admin and use:
+
+ * `> wsl --shutdown` to shutdown all WSLs
+
+ * `> wsl -l -v` to show status of all WSLs.
+
+To access your Windows filesystem from WSL look in directory `/mnt/c`. Note however that if you've cloned the baseline repo using Windows tools into the Windows filesystem, you will still need to clone it into the Linux filesystem (step 2 above) to successfully run the Quickstart. 
+
+#### Docker Info
+During Quickstart, many Docker containers are built. You can follow progress by opening a new Ubuntu terminal (shift-click on Ubuntu icon) and periodically typing:
+```
+$ docker info
+```
+This lets you see how many containers are running.
+
+


### PR DESCRIPTION
# Description
Documentation enhancements. Edited the [root README.md](https://github.com/ethereum-oasis/baseline#quickstart) **quickstart** section to link to a new page detailing setup instructions for Windows 10 users. Windows users need to setup WSL2 before executing the rest of the quickstart instructions.

## Related Issue
https://github.com/ethereum-oasis/baseline/issues/179

## Motivation and Context
The quickstart instructions assume Linux without saying so. For Windows users it is not at all obvious what they should do to get the radish34 quickstart working. The solution is to use the Windows Subsystem for Linux (WSL) but for many Windows users, WSL may be unfamiliar and there is lots of setup to do (npm, docker etc) before the quickstart will work. 

## How Has This Been Tested
I have tested the instructions myself on WSL2 with Ubuntu.

## Types of changes
Documentation change only.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
