### PR TITLE
Add: Table of Contents and General Readme to docs/community

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,0 +1,314 @@
+
+[**publication**](https://medium.com/baselineprotocol)
+
+
+
+
+
+## Open Source Community
+
+The Baseline Protocol initiative was [announced](https://consensys.net/blog/press-release/ey-and-consensys-announce-formation-of-baseline-protocol-initiative-to-make-ethereum-mainnet-safe-and-effective-for-enterprises/) on March 4, 2020 and launched as an [OASIS](https://oasis-open-projects.org/) open source project on March 19, 2020, supported by fourteen founding companies. The initiative is strongly aligned with the Mainnet Working Group, a joint effort of the [Enterprise Ethereum Alliance](https://entethalliance.org) and the [Ethereum Foundation](https://ethereum.org).
+
+> This work is active and open to contributors.
+
+All work in the [Baseline Protocol public repo](https://github.com/ethereum-oasis/baseline) is released under the CC0 1.0 Universal public domain dedication. For the full license text, refer to [`license.md`](https://github.com/ethereum-oasis/baseline/blob/master/license.md).
+
+## **Leadership**
+
+In an openly governed open standards / open source initiative, leadership is organic. One need not be seated to a committee to lead. One need not be the chair to lead the community in a direction. \(Indeed, the chair's primary job is to harmonize the interests of others and help the community move to a shared vision, not necessarily to forward their own point of view.\)  
+
+> **The way to lead is to start something, help something, fix something...even spellcheck something!  The way to lead is to get others to amplify what you are doing \(best done by listening deeply to others first\). The way to lead is to serve your own \(and your company's\) enlightened self interest. You should be able to draw a straight line from your time on this work to real impact for your own offerings.**
+
+Below are the things you need to know to get informed, get involved and get value out of the work.
+
+## Working Together
+
+### Meetings and Meetups
+
+Check the [**group calendar**](https://lists.oasis-open-projects.org/g/baseline/calendar) for times/dates of online \(and eventually face to face\) meetings. If the times we have don't work for your timezone, we can do 1-1's or make changes to the schedule. Chime in on the [**Slack**](https://communityinviter.com/apps/ethereum-baseline/join-us)...don't be shy.
+
+#### Onboarding: Help Getting Started
+
+It's critical that new contributors have a good idea about what the focal points of the community are and where one can make a real impact. Hard to beat having a real conversation about how to get started in an intimate setting where you can ask questions and get immediate answers. ****
+
+We will hold Onboarding office hours twice a week at least until June 2020. Sign up, or reach out on Slack to ask for 1-1 time. 
+
+#### **Roadmapping**
+
+There will be sessions \(online for now during the period of global pandemic\) to dive deep on the technology. Check the [calendar](https://lists.oasis-open-projects.org/g/baseline/calendar) for details. 
+
+#### Technical Steering Committee
+
+The [TSC](community-members.md#your-technical-steering-committee) will meet typically once a month, biweekly during the early direction setting period from March to June of 2020. Members of the TSC can check the TSC [sub-group calendar](https://lists.oasis-open-projects.org/g/baseline-tsc/calendar) and receive invitations.
+
+#### Specifications Steering Committee
+
+The [SSC](community-members.md#your-specifications-steering-committee) will meet typically once a month, biweekly during the early direction setting period from March to June of 2020. Members of the SSC can check the SSC [sub-group calendar](https://lists.oasis-open-projects.org/g/baseline/subgroups) and receive invitations.
+
+### Connecting with Each Other Directly
+
+#### Slack
+
+The Baseline Protocol initiative maintains a Slack channel that is moderated but public. Sign up [**here**](https://communityinviter.com/apps/ethereum-baseline/join-us).  It's an active group, and you can directly connect with folks doing the work and coordinate with each other to get the work done.
+
+#### Members Directory
+
+You can [**sign up**](https://lists.oasis-open-projects.org/g/baseline) to the baseline protocol members list and get access to the [**Directory**](https://lists.oasis-open-projects.org/g/baseline/directory). This will show you any members who have elected to be displayed publicly. There are others who will choose to be hidden but will receive group emails.
+
+#### Group Email
+
+When you [sign up](https://lists.oasis-open-projects.org/g/baseline) in the members directory, you will have the option to get email that's sent to the mailing list or directly from anyone in the group. You can control how that impacts your inbox [**here**](https://lists.oasis-open-projects.org/g/baseline/editsub). 
+
+#### Forums
+
+The team hasn't yet set up a Reddit or other public forum, but several new members are already talking about doing that. Stay tuned or help make it happen.
+
+#### Social Networking
+
+The Baseline Protocol initiative maintains the [@baselineproto](https://twitter.com/baselineproto) Twitter account, to which members of the TSC, SSC and some maintainers can post. We also use the [\#baselineprotoco](https://twitter.com/hashtag/Baselineprotocol)l tag.
+
+#### Medium
+
+The Baseline Protocol initiative will use Medium to post blogs. Here is the [**publication**](https://medium.com/baselineprotocol).  Reach out on Slack to the chair, OASIS team or members of the steering committees, if you want to be a writer or editor.
+
+<!-- END OF COMMUNITY.md -->
+
+
+<!-- START OF CONTRIBUTORS-GUIDE.md -->
+# Contributors Guide
+
+All work of the Baseline Protocol initiative is maintained publicly at: [https://github.com/ethereum-oasis/baseline](https://github.com/ethereum-oasis/baseline)
+
+There are four ways to contribute: 
+
+* Write code \(Architecture, Spikes, Issues, Tasks\) 
+* Write specifications \(Epics, Stories, [Standards](../baseline-protocol/standards/), Prioritizations, Use Cases\)
+* Write content and communicate it to more potential contributors, developers and product owners, and other stakeholders;
+* Help prioritize work and develop incentives to get it done. 
+
+There is one other way to contribute, and it's the most important: use the work in the Baseline Protocol to improve your own offerings. The Baseline Protocol is not a product or platform..the product is YOUR product. 
+
+## Technical Contributors
+
+Technical contributors either are working on architecture or developing code...but even correcting poorly written in-line docs counts as a technical contribution and qualifies you to vote in an upcoming [TSC](community-members.md#your-technical-steering-committee) election.
+
+### Issues Organization and Community "Sprints"
+
+Technical tasks are written as Github Issues. Issues will be reviewed, lightly prioritized, and communicated as "hey, help out here!" messaging to the developer community every two weeks. The TSC will periodically review what Issues and communications best succeeded in attracting help.
+
+An Issue should be constructed, in particular, with acceptance tests. All other elements of a good Issue should be known to any practicing developer. 
+
+Most Issues should be attached to an Epic \(see below\).
+
+A good Task/Issue starts with a Verb: "Implement xyz."
+
+### Submitting a pull request
+
+Follow these steps when submitting a pull request:
+
+1. Fork the repo into your GitHub account. Read more about forking a repo on Github [here](https://help.github.com/articles/fork-a-repo/).
+2. Create a new branch, based on the `master` branch, with a name that concisely describes what you’re working on \(ex. `add-mysql`\).
+3. Ensure that your changes do not cause any existing tests to fail.
+4. Submit a pull request against the `master` branch.
+
+Good practice strongly favors committing work frequently and not loading up a long period of work in isolation. Be brave...let others see what you are working on, even if it isn't "ready."
+
+### eCLA and iCLA
+
+Anyone can do a pull request and commit. In order for your work to be merged, you will need to sign the eCLA \(entity contributor agreement\) or iCLA \(individual contributor agreement\). Here are the details: [https://www.oasis-open.org/resources/projects/cla/projects-entity-cla](https://www.oasis-open.org/resources/projects/cla/projects-entity-cla)
+
+The iCLA happens automatically when people submit a pull request, or they can access directly by going to [https://cla-assistant.io/ethereum-oasis/baseline](https://cla-assistant.io/ethereum-oasis/baseline)
+
+### Maintainers and Commit Rules
+
+During the bootstrap phase \(March - June, 2020\) merging to Master will require review by THREE Maintainers. The TSC will seed the set of Maintainers. Thereafter, any active Committer can become a Maintainer. Maintainers may add more Maintainers by simple majority and \(rough consensus rules\), and the TSC may step in to resolve cases where this process fails. 
+
+## Specifications Contributors
+
+The specifications work of the community can be done by anyone, both technical and non-technical contributors. The focus is on finding evidence for a requirement and articulating it in the form below. The [SSC](community-members.md#your-specifications-steering-committee) is the coordinating body for this work.
+
+### Epics, Stories Organization
+
+The Baseline Protocol initiative uses [Zenhub](https://github.com/ethereum-oasis/baseline/tree/master/radish34/ui#workspaces/baseline-5e713dc4f555144d9d6d17f6/board?repos=239590893) to create and manage both [specification](https://github.com/ethereum-oasis/baseline/tree/master/radish34/ui#workspaces/baseline-5e713dc4f555144d9d6d17f6/roadmap?repos=239590893) work and active protocol requirements and prioritization. \(Zenhub should be a tab in your Github interface. There is a Chrome plugin also.\)
+
+Zenhub enables Epics to nest, while Issues don't nest...not really.  Therefore, the community will employ the practice of using Issues for engineering Tasks and Epics to contain high level topics, which may have nested within them a set of agile Epics, and in them a set of Stories, and even Stories may have other Stories nested in them.  Engineering meets planning where a Story \(in the form of a Zenhub Epic\) is referenced by an Issue/Task. \(This can work very well, but Zenhub's choice in calling Epics, _Epics_ can cause confusion.
+
+### A Good Story
+
+A Zenhub "Epic" used as a high-level container for a grouping of work should be in short topic form -- primarily nouns.
+
+A Zenhub "Epic" used as a Story should almost always follow the form: "As X, I need Y so that I can Z."  An acceptable variant is the "now I can" form \(note the "so that" clause is preserved\): 
+
+* [ ] A  Party's System Administrator can look up Counterparties in an OrgRegistry \(a public phone book\) and add them to a Workgroup, so that they can start Baselining Records and Workflows.
+* [ ] A Party's System Administrator can quickly and easily verify a Counterparty's identity found in the OrgRegistry, so that they can be confident in adding the Counterparty to a Workgroup.
+* [ ] A Party's System Administrator can use some or all of the Counterparities and Workflow Steps defined in one Workgroup in Workflow Steps created within another Workgroup, so that Workgroups don't become yet another kind of silo. 
+
+## Task Groups
+
+There are no special task groups yet, but stay tuned. 
+
+Task Groups \(aka sub-groups in the [members portal](https://lists.oasis-open-projects.org/g/baseline/subgroups)\) can form to tackle an Industry Vertical, focus on a horizontal category like Cloud or B2B Contracting, or develop ways to integrate with a particular platform such as Corda or any of the Hyperledger projects. 
+
+To set up a Task Group, simply get committed people together, find and embrace others that might be forming something similar, communicate your plans, and get to work.
+
+<!-- END OF CONTRIBUTORS-GUIDE.md -->
+
+
+<!-- START OF GOVERNANCE.md -->
+# Governance
+
+## OASIS and Governance
+
+OASIS Open is a non-profit, vendor-neutral standards developing organization. It provides rules and guidelines to ensure equitable and transparent oversight of technical collaborations in open source and open standards.  Additionally, it provides services such as technical program support, legal, marketing, and events management.
+
+The Baseline Protocol is governed by the [Ethereum OASIS Project Governing Board](https://www.baseline-protocol.org/about/) under the [OASIS Open Projects Program](http://oasis-open-projects.org/).  Ethereum OASIS exists to provide a neutral forum for companies and community representatives to create high-quality specifications that facilitate Ethereum’s longevity, interoperability, and ease of integration.  One does not have to "join" the group formally or financially  in order to make a contribution to Baseline or other Ethereum OASIS projects.  
+
+Additional documentation about the OASIS Open Projects program can be found [here](https://github.com/oasis-open-projects/documentation).  
+
+## License and Patent Policies
+
+All repos in the Ethereum OASIS organization, including Baseline Protocol repositories, adhere to OASIS Open Projects [license](https://github.com/oasis-open-projects/documentation/blob/master/policy/licenses.md) and [patent polices](https://github.com/oasis-open-projects/documentation/blob/master/policy/call-for-patent-disclosure.md). 
+
+In order to ensure clean IPR that allows Baseline to remain an open technology, OASIS rules require an [Entity CLA](https://www.oasis-open.org/resources/projects/cla/projects-entity-cla) for persons or organizations contributing on behalf of a legal entity, and an [Individual CLA](http://cla-assistant.io/ethereum-oasis/baseline) for community contributions. You must [sign the ICLA](http://cla-assistant.io/ethereum-oasis/baseline) before your pull requests to the baseline repository will be merged. [Check here](https://www.oasis-open.org/resources/projects/cla/projects-view-entity-cla) to see if your company has signed the ECLA. 
+
+## **Charter: Baseline Open Source Project Governance**
+
+**Ratified on March 18, 2020 by the** [**PGB**](community-members.md#your-project-governance-board)**.**
+
+The Baseline Protocol shall be a project within the Ethereum-Oasis project of [OASIS](https://www.oasis-open.org/) through at least May 31, 2020. The Project Governing Board \(PGB\) of the Ethereum-OASIS project, which was established in 2019 and is currently supported by the EEA and the Ethereum Foundation \(EF\), currently consists of  Dan Burnett \(ConsenSys\), Tas Dienes \(EF\), and Chaals Neville \(EEA\) – supported by Jory Burson \(OASIS\). The Baseline Project shall be supported under the existing contract with OASIS and shall require no additional fees than those already paid by EEA/EF and the parties to the Open Ethereum Project until May 31, 2020. Negotiation to continue the Baseline Project with OASIS shall be conducted between March and May 2020. 
+
+
+#### TSC
+
+The Baseline Protocol shall be governed by a Technical Steering Committee, with 7, 9 or 11 Members, one of whom will serve as TSC Chair. The initial number of seats for the bootstrapping period \(see below\) shall be 11. 
+
+A quorum of two-thirds of the TSC members can conduct any vote required of the TSC during any given meeting. Disputes on whether a matter should be tabled for a different TSC meeting can be presented to the PGB of the Ethereum-OASIS project for a decision. A move to table a matter can be lodged during a TSC meeting, and it shall be tabled and submitted to the PGB with a simple majority vote. If a majority cannot be achieved during the meeting, a minimum of two members that were present at the meeting in question may dispute the matter after the fact to the PGB.
+
+No legal entity \(or set of entities controlled by a single party\) shall hold more than three seats out of eleven \(or two seats out of seven or nine\) on the TSC during any given period. 
+
+A TSC member is eligible to lose their seat upon missing two consecutive TSC meetings or three total during a period between elections. Removal is completed by a simple majority vote of the remaining TSC members that are not being considered for removal. The PGB of the Ethereum-OASIS project has the option to consider extenuating circumstances and determine whether or not to remove a member, if the TSC itself cannot come to a determination. After removal, a special election of the vacant seat shall be held among contributors. The seat will be up for re-election at the next regular election cycle.
+
+#### Bootstrapping Period:  
+
+In all cases \(7, 9 or 11 member TSC\), the original three organizations \(EY, MSFT, ConsenSys\) hold less than 50% of the seats, during the initial six month bootstrapping period.
+
+One TSC Member shall serve as provisional chair of the TSC for six months. On September 31, 2020, all members and the chair shall be open for new elections. Members of the community shall have voting rights based on contribution \(see below\):  
+
+
+#### Steady State Periods: 
+
+After the six month Bootstrap Period, there shall be a nomination and election period for electing TSC members, typically from the ranks of Contributors and Maintainers. The TSC voting members shall consist of eleven \(7, 9 or 11\) elected members chosen by Active Contributors. An Active Contributor is defined as any Contributor who has had a contribution accepted into the Master Branch of the codebase during the prior six \(6\) months. The TSC shall approve the process and timing for nominations and elections held on an annual basis.
+
+#### Maintainers: 
+
+Contributors who have the ability to commit code and contributions to a repo's main branch on the Baseline Protocol. A Contributor may become a Maintainer by a majority approval of the existing Maintainers. The initial number of maintainers required to merge a pull request to master in the github repo shall be three, but may be amended to no fewer than two by a simple majority of the maintainers.
+
+#### Contributors: 
+
+Anyone in the technical community that contributes code, documentation or other technical artifacts to the Baseline codebase or Standards Specification.
+
+#### Contributions: 
+
+The TSC shall determine the number of maintainers required to merge a contribution into the master branch of the repo. This shall be done during the first TSC meeting. Changes to this number require a simple majority of TSC members.  
+
+#### Ratification
+
+This document shall be ratified by the PGB before the public launch of the Baseline Protocol. Changes to this document shall require a simple majority of the PGB.
+
+#### Details on OASIS and the Open Ethereum Project
+
+Governance documents from the existing Open Ethereum Project:  [https://notes.ethereum.org/zE2f1mIcTf2jjfdmTOZx3w?view](https://notes.ethereum.org/zE2f1mIcTf2jjfdmTOZx3w?view)
+
+<!-- END OF GOVERNANCE.md -->
+
+
+
+<!-- START OF COMMUNITY-MEMBERS.md -->
+## Community Members
+
+Over 400 people and companies signed up to be notified about the opening of the Baseline Protocol Github repository between March 4th and 19th, 2020. Over 300 of them also signed in as group members. The [members](https://lists.oasis-open-projects.org/g/baseline/directory) represent many of the largest companies in the world, spanning several sectors. They also represent startups, students and talented individuals.
+
+### Bootstrapping Phase and Ongoing Phase
+
+The technical steering committee and the chair listed below will be seated provisionally for six months, from From March 19, 2020 to September 31, 2020. This bootstrapping period will end when the active contributors to the repo \(anyone who has submitted a pull request that was merged to master in the preceeding period\) vote on the new TSC and chair. The specifications steering committee \(SSC\) has a variable number, and membership is based on
+
+The people and companies listed below have stepped up to identify themselves as supporters, stakeholders, responsible parties, and accountable parties to help bootstrap the Baseline Protocol work.
+
+### Your Project Governance Board
+
+The project governance board \(PGB\) is organized by OASIS and is accountable for ensuring the balance and integrity of the Ethereum-Oasis initiatives, such as the Baseline Protocol.
+
+| Name | Organization |
+| :--- | :--- |
+| [**Chaals Neville**](https://www.linkedin.com/in/chaals/) | Enterprise Ethereum Alliance |
+| [**Dan Burnett**](https://www.linkedin.com/in/daburnett/) | PegaSys |
+| [**Tas Dienes**](https://www.linkedin.com/in/tasdienes/) | Ethereum Foundation |
+
+### Your Technical Steering Committee
+
+The technical steering committee \(TSC\) is accountable to the Project Governance Board for bootstrapping the maintainer group, stepping in to resolve any conflicts on merges or maintainer self-organization
+
+| Name | Company |
+| :--- | :--- |
+| [**Brian Chamberlain**](https://www.linkedin.com/in/blchamberlain/) | ConsenSys |
+| [**Conor Svensson**](https://www.linkedin.com/in/conor10/) | Web3Labs |
+| [**Eric Bravick**](https://www.linkedin.com/in/ebravick/) | Core Convergence |
+| [**Hudson Jameson**](https://www.linkedin.com/in/hudsonjameson/) | Ethereum Foundation |
+| [**Johann Eid**](https://www.linkedin.com/in/johanneid/) | Chainlink |
+| [**Kartheek Solipuram**](https://www.linkedin.com/in/kartheek-solipuram-62970a8/) | Ernst & Young |
+| [**Kyle Thomas**](https://www.linkedin.com/in/kylebthomas/) | Provide |
+| [**Nate McKervey**](https://www.linkedin.com/in/mckervey/) | Splunk |
+| [**Stefan Schmidt**](https://www.linkedin.com/in/stefschmidt/) | Unibright |
+| [**Zachary Williamson**](https://www.linkedin.com/in/zachary-williamson-b02b0192/) | Aztec |
+
+### Your Specifications Steering Committee
+
+The specifications committee \(SSC\) is responsible for organizing the community and helping set functional and non-functional requirements as well as targeting use cases, industry verticals, and horizontal platforms & products. These are senior industry executives and influencers who can rally support for the work and help find ways to structure incentives for people to focus on key Epics and Stories in the [repo](https://github.com/ethereum-oasis/baseline). \(Note, epics and stories maintained in [Zenhub](https://github.com/ethereum-oasis/baseline#workspaces/baseline-5e713dc4f555144d9d6d17f6/board?repos=239590893).
+
+SSC members are seated by consensus of the sitting members. There is no specific maximum number of seats, and it is expected that the members will form sub-committees for topics like industry verticals.
+
+| Name | Company |
+| :--- | :--- |
+| [**Arwin Holmes**](https://www.linkedin.com/in/arwinholmes/) | Ernst & Young |
+| [**Bill Gleim**](https://www.linkedin.com/in/williamgleim/) | ConsenSys Health |
+| [**Daniel Norkin**](https://www.linkedin.com/in/danielnorkin/) | Envision Blockchain |
+| [**Joerg Roskowetz**](https://www.linkedin.com/in/joergroskowetz/) | AMD |
+| [**Jon Stevens**](https://www.linkedin.com/in/lookfirst/) | Web3Cloud |
+| [**Joseph Bala**](https://www.linkedin.com/in/josephbala/) | Neocova |
+| [**Karen Scarborough**](https://www.linkedin.com/in/karenscarbrough/) | BP |
+| [**Stephan Baur**](https://www.linkedin.com/in/stephanbaur/) | Kaiser Permanente |
+| Steve Shortt | BP |
+| [**Yorke Rhodes**](https://www.linkedin.com/in/yorkerhodes/) | Microsoft |
+
+### Your Provisional Chair
+
+The chair of the Baseline Protocol initiative steering committees is an elected position, accountable to both the PGB and the community to provide organizing services and to ensure the harmonization of the intentions of the stakeholders and contributors to the work.
+
+The position is annual and chosen by popular vote of contributors who have had work merged to the master branch of the repo in the previous period.
+
+| Name | Company |
+| :--- | :--- |
+| [**John Wolpert**](https://www.linkedin.com/in/johnwolpert/) | ConsenSys |
+
+## Founding Group on March 4, 2020
+
+### [**AMD**](https://www.amd.com/en/technologies/blockchain)**,** [**EY**](https://blockchain.ey.com/)**,** [**ChainLink**](https://chain.link/)**,** [**Core Convergence**](https://www.coreconvergence.us/)**,** [**ConsenSys**](https://consensys.net/)**,** [**Duke University**](https://pratt.duke.edu/)**,** [**Envision Blockchain**](https://envisionblockchain.com/)**,** [**MakerDAO**](https://makerdao.com/en/)**,** [**Microsoft**](http://www.microsoft.com/)**,** [**Neocova**](https://neocova.com/)**,** [**Splunk**](https://www.splunk.com/)**,** [**Unibright**](https://unibright.io/)**,** [**Provide**](https://provide.services/)**, and** [**W3BCLOUD**](https://www.w3bcloud.com/)**.**
+
+## New Stakeholders: March 19, 2020
+
+### [**Aztec**](https://www.aztecprotocol.com/)**,**  [**ConsenSys Health**](https://consensyshealth.com)**,**  [**Anyblock Analytics GmbH**](https://anyblockanalytics.com)**,**  [**Ocyan Cloud Technology LTD**](https://ocyan.com)**,**  [**Digital Scarcity**](http://digitalscarcity.io/)**,** Energy Web Foundation, The Graph, ShipChain, [Clear](https://www.clearx.io/)
+
+Stay tuned...more coming in all the time.
+
+## Contributors and Maintainers
+
+Stay tuned as the community bootstraps.
+
+| Name | Github Handle | Company |
+| :--- | :--- | :--- |
+|  |  |  |
+
+
+#### License
+
+Contributions to the open source repo shall be under creative commons public domain license [\(CC0 1.0 Universal\)](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,8 +1,53 @@
+<!-- 
+Contributions to the open source repo shall be under creative commons public domain license [\(CC0 1.0 Universal\)](https://creativecommons.org/publicdomain/zero/1.0/).
+-->
 
-[**publication**](https://medium.com/baselineprotocol)
+# Baseline Community
 
-
-
+- [Baseline](#baseline)
+  * [Open Source Community](#open-source-community)
+  * [**Leadership**](#--leadership--)
+  * [Working Together](#working-together)
+    + [Meetings and Meetups](#meetings-and-meetups)
+      - [Onboarding: Help Getting Started](#onboarding--help-getting-started)
+      - [**Roadmapping**](#--roadmapping--)
+      - [Technical Steering Committee](#technical-steering-committee)
+      - [Specifications Steering Committee](#specifications-steering-committee)
+    + [Connecting with Each Other Directly](#connecting-with-each-other-directly)
+      - [Slack](#slack)
+      - [Members Directory](#members-directory)
+      - [Group Email](#group-email)
+      - [Forums](#forums)
+      - [Social Networking](#social-networking)
+      - [Medium](#medium)
+- [Contributors Guide](#contributors-guide)
+  * [Technical Contributors](#technical-contributors)
+    + [Issues Organization and Community "Sprints"](#issues-organization-and-community--sprints-)
+    + [Submitting a pull request](#submitting-a-pull-request)
+    + [eCLA and iCLA](#ecla-and-icla)
+    + [Maintainers and Commit Rules](#maintainers-and-commit-rules)
+  * [Specifications Contributors](#specifications-contributors)
+    + [Epics, Stories Organization](#epics--stories-organization)
+    + [A Good Story](#a-good-story)
+  * [Task Groups](#task-groups)
+- [Governance](#governance)
+  * [OASIS and Governance](#oasis-and-governance)
+  * [License and Patent Policies](#license-and-patent-policies)
+  * [**Charter: Baseline Open Source Project Governance**](#--charter--baseline-open-source-project-governance--)
+      - [TSC](#tsc)
+      - [Bootstrapping Period:](#bootstrapping-period-)
+      - [Steady State Periods:](#steady-state-periods-)
+      - [Maintainers:](#maintainers-)
+      - [Contributors:](#contributors-)
+      - [Contributions:](#contributions-)
+      - [Ratification](#ratification)
+      - [Details on OASIS and the Open Ethereum Project](#details-on-oasis-and-the-open-ethereum-project)
+  * [Community Members](#community-members)
+    + [Bootstrapping Phase and Ongoing Phase](#bootstrapping-phase-and-ongoing-phase)
+    + [Your Project Governance Board](#your-project-governance-board)
+    + [Your Technical Steering Committee](#your-technical-steering-committee)
+    + [Your Specifications Steering Committee](#your-specifications-steering-committee)
+    + [Your Provisional Chair](#your-provisional-chair)
 
 
 ## Open Source Community
@@ -12,6 +57,8 @@ The Baseline Protocol initiative was [announced](https://consensys.net/blog/pres
 > This work is active and open to contributors.
 
 All work in the [Baseline Protocol public repo](https://github.com/ethereum-oasis/baseline) is released under the CC0 1.0 Universal public domain dedication. For the full license text, refer to [`license.md`](https://github.com/ethereum-oasis/baseline/blob/master/license.md).
+
+Read the [**publication**](https://medium.com/baselineprotocol)
 
 ## **Leadership**
 


### PR DESCRIPTION
## Feature request: Documentation Table of Contents per section

## Example
SEE `README.md` in `docs/community`


## Feature Implementation Details
No changes other than:

Create a README file that has a `table of contents` so that new users can quickly find out where specific topics are addressed, such as `membership`, `contributing guidelines`, etc.

## Changes Made
```
<!-- CC-0 Notice -->
<!-- BEGINING OF FILENAME.md -->
<!-- END OF FILENAME.md -->
```

## Files Affected:
`README.md` only.
