### PR TITLE
Pin nethermind image in core/api test harness

### DIFF
--- a/core/api/package.json
+++ b/core/api/package.json
@@ -14,7 +14,7 @@
     "build:umd": "webpack",
     "build": "yarn clean && yarn build:cjs && yarn build:umd",
     "clean": "rm -rf ./dist",
-    "nethermind:start": "npm run nethermind:stop 2&>/dev/null && docker run -td -p 8545:8545 provide/nethermind --config baseline --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.Port 8545 --KeyStore.TestNodeKey 120102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f && sleep 2",
+    "nethermind:start": "npm run nethermind:stop 2&>/dev/null && docker run -td -p 8545:8545 provide/nethermind:stable --config baseline --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.Port 8545 --KeyStore.TestNodeKey 120102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f && sleep 2",
     "nethermind:stop": "docker stop $(docker ps | grep provide/nethermind | sed 's/ .*//') || true",
     "test": "npm run test:startup && ./node_modules/.bin/jest --verbose --color --passWithNoTests --testTimeout 10000 && npm run test:teardown",
     "test:startup": "npm run nethermind:start",

--- a/core/api/test/baseline-rpc.spec.ts
+++ b/core/api/test/baseline-rpc.spec.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 import { baselineProviderRpc, baselineServiceFactory } from '../src/index';
+import { promisedTimeout } from './utils';
 
 const defaultAccountAddress = '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf';
 
@@ -11,7 +12,8 @@ const deployShield = async () => {
   const txhash = await rpc.exec('baseline_deploy', [sender, 'MerkleTreeSHA']);
   expect(txhash).not.toBe(null);
   expect(txhash.length).toBe(66);
-
+  // wait for the block to be processed
+  await promisedTimeout(50);
   const receipt = await rpc.fetchTxReceipt(txhash);
   expect(receipt).not.toBe(null);
   expect(receipt.contractAddress).not.toBe(null);
@@ -57,6 +59,8 @@ describe('off-chain merkle tree tracking', () => {
         leaf = ethers.utils.keccak256(ethers.utils.hexlify(ethers.utils.toUtf8Bytes(`${new Date().getTime()}`)));
         const insertResult = await rpc.insertLeaf(sender, shield, leaf);
         expect(insertResult).not.toBe(null);
+	// wait for the block to be processed
+        await promisedTimeout(50);
       });
 
       it('should create a valid root in the tree', async () => {

--- a/core/api/test/provide.spec.ts
+++ b/core/api/test/provide.spec.ts
@@ -7,7 +7,6 @@ let bearerToken;
 let provide;
 
 beforeEach(async () => {
-  // FIXME bearerToken = ;
   provide = await baselineServiceFactory(baselineProviderProvide);
 });
 


### PR DESCRIPTION
# Description

Pin the Nethermind image in `core/api` test harness.

## Motivation and Context

The test suite was intermittently failing.

## How Has This Been Tested

`npm test` (under `core/api`)

```
➜  api git:(pin-nethermind) npm test

(...snip...)

 PASS  test/baseline-rpc.spec.ts (10.893s)
  off-chain merkle tree tracking
    when no shield contract has been deployed to the given address
      ✓ should return false to indicate no new merkle tree is being tracked or persisted (185ms)
    when the given address is a valid merkle tree shield contract
      ✓ should return true to indicate a new merkle tree db was created and tracking started (1493ms)
      inserting a leaf
        ✓ should create a valid root in the tree (1404ms)
        ✓ should expose the leaf in the tree (1371ms)
        ✓ should expose the leaves in the tree (1325ms)
        ✓ should expose the sibling paths of the leaf (1300ms)
        verification of a leaf against a root and siblings path
          when the given leaf should not be verified against the root and siblings
            ✓ should not verify the leaf against the root and sibling paths (1338ms)
          when the given leaf can be verified against the root and siblings
            ✓ should verify a leaf against the root and sibling paths (1308ms)

 PASS  test/provide.spec.ts (10.921s)
  baseline rpc
    off-chain merkle tree tracking
      when no shield contract has been deployed to the given address
        ✓ should return false to indicate no new merkle tree is being tracked or persisted (183ms)
      when the given address is a valid merkle tree shield contract
        ✓ should return true to indicate a new merkle tree db was created and tracking started (1495ms)
        inserting a leaf
          ✓ should create a valid root in the tree (1404ms)
          ✓ should expose the leaf in the tree (1370ms)
          ✓ should expose the leaves in the tree (1326ms)
          ✓ should expose the sibling paths of the leaf (1303ms)
          verification of a leaf against a root and siblings path
            when the given leaf should not be verified against the root and siblings
              ✓ should not verify the leaf against the root and sibling paths (1336ms)
            when the given leaf can be verified against the root and siblings
              ✓ should verify a leaf against the root and sibling paths (1336ms)

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        11.9s
Ran all test suites.
```

## Types of changes

Fixes an intermittent race condition in the `core/api` test suite related to async block production within the Nethermind client. The Nethermind client image is now pinned to the `stable` tag during test harness initialization.