### PR TITLE
Fix jsonrpc bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 Version 0.1 of the baseline protocol packages has been released! For some background information, check out [this section](https://docs.baseline-protocol.org/baseline-protocol/the-baseline-protocol) of our docs. There are two entrypoints where you can get involved in the codebase:
 - [`core/`](https://github.com/ethereum-oasis/baseline/tree/master/core) -- the "core" Baseline Protocol packages
-- [`examples/bri-1`](https://github.com/ethereum-oasis/baseline/tree/master/examples/bri-1/base-example) -- the BRI-1 reference implementation
-One or more "core" baseline protocol packages are needed to baseline-enabled applications and systems of record.
+- [`examples/bri-1`](https://github.com/ethereum-oasis/baseline/tree/master/examples/bri-1/base-example) -- the BRI-1 reference implementation.
+One or more "core" baseline protocol packages are needed to baseline-enable applications and systems of record.
 
 ## Core Modules & Packages
 | Package | Source Path | Description |

--- a/core/README.md
+++ b/core/README.md
@@ -2,7 +2,7 @@
 
 ![baseline-protocol-architecture](https://user-images.githubusercontent.com/161261/86484557-79504f00-bd24-11ea-8edb-d665cb55db20.png)
 
-One or more "core" baseline protocol packages are needed to baseline-enabled applications and systems of record.
+One or more "core" baseline protocol packages are needed to baseline-enable applications and systems of record.
 
 ## Modules & Packages
 

--- a/core/api/src/providers/rpc/service.ts
+++ b/core/api/src/providers/rpc/service.ts
@@ -28,7 +28,7 @@ export class Rpc implements IBaselineRPC, IBlockchainService, IRegistry, IVault 
       id: this.id++,
       method: method,
       params: params,
-      version: this.version,
+      jsonrpc: this.version,
     });
 
     const data = resp ? resp.data : null;

--- a/core/persistence/README.md
+++ b/core/persistence/README.md
@@ -1,6 +1,6 @@
 # @baseline-protocol/persistence
 
-Baseline core persistence package.
+This package is under development for a future release. When complete, it will facilitate connection to systems of record, i.e. databases. This package is not required for implementation of the Baseline Protocol v0.1.
 
 ## Installation
 


### PR DESCRIPTION
# Description

- Updated some READMEs
- Changed the `version` field to `jsonrpc` in requests made by `rpc` provider

## Motivation and Context

Current requests made when using `rpc` as the provider for `core/api` are incompatible with current json-rpc standard.

## How Has This Been Tested

Ran `npm test` inside `core/api`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
