### PR TITLE
Update maintainers and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # the following owers will be requested for
 # review when someone opens a pull request.
-*       @skarred14 @bitwiseguy @pmacom @breakpointer @kthomas
+*       @skarred14 @bitwiseguy @breakpointer @kthomas

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,12 +17,12 @@ Maintainers are people who take an active role in writing code that advances the
 
 Code and Systems maintainers
   - [Sam Stokes](https://github.com/bitwiseguy) 
-  - [Patrick Macom](https://github.com/pmacom)
   - [Kartheek Solipuram](https://github.com/skarred14)
   - [Brian Chamberlain](https://github.com/breakpointer)
   - [Kyle Thomas](https://github.com/kthomas)
   - [George Spasov](https://github.com/Perseverance)
   - [Tomasz Stanczak](https://github.com/tkstanczak)
+  - [Lucas Rodriguez Benitez](https://github.com/LucasRodriguez)
 
 # How to become a maintainer?
 


### PR DESCRIPTION
This PR serves as a voting ballot for changes in the maintainer team. As stated in the baseline docs, a 2/3 majority vote is needed for these changes to pass. Only votes from current maintainers will be considered valid. There are currently 7 maintainers, so at least 5 must approve for the changes to be accepted.
