### PR TITLE
Add Anais Ofranc to maintainers team

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,7 @@ Code and Systems maintainers
   - [George Spasov](https://github.com/Perseverance)
   - [Tomasz Stanczak](https://github.com/tkstanczak)
   - [Lucas Rodriguez Benitez](https://github.com/LucasRodriguez)
+  - [Anais Ofranc](https://github.com/Consianimis)
 
 # How to become a maintainer?
 

--- a/docs/community/community-leaders.md
+++ b/docs/community/community-leaders.md
@@ -108,6 +108,7 @@ Details on how to become a [Maintainer here](members.md).
 | \*\*\*\*[**Kyle Thomas**](https://github.com/kthomas)\*\*\*\* | Provide |
 | \*\*\*\*[**Tomasz Kajetan Stańczak**](https://www.linkedin.com/in/tomaszkajetanstanczak/)\*\*\*\* | Nethermind |
 | [**George Spasov**](https://www.linkedin.com/in/george-spasov/)\*\*\*\* | LimeChain |
+| [**Anais Ofranc**](https://github.com/Consianimis)\*\*\*\* | Consianimis |
 
 ## Founding Group on March 4, 2020 <a id="founding-group-on-march-4-2020"></a>
 


### PR DESCRIPTION
# Description

Maintainers team voted unanimously to add Anais Ofranc to the maintainers team. This PR changes documentation to reflect the new team members.