### PR TITLE
Add BaselineState to @baseline-protocol/types

### DIFF
--- a/core/persistence/README.md
+++ b/core/persistence/README.md
@@ -9,3 +9,49 @@ This package is under development for a future release. When complete, it will f
 ## Building
 
 You can build the package locally with `npm run build`.
+
+## Baseline State Tracking
+
+```typescript
+BaselineState: {
+  
+  // Underlying document identification and location information
+  offchainLocation: {
+    dbUrl: String,
+    collectionName: String,
+    documentId: String, // UUID,
+    baselinedFields: String[],
+  }
+
+  // Counter-parties
+  counterParties: [{
+    messagingEndpoint: String,
+    name: String,
+    currentHash: String
+  }],
+
+  // Possible states:
+  // 1: based: currentHash === on-chain commitment
+  // 2. debased: currentHash !== on-chain commitment
+  currentState: String,
+  
+  // currentHash = H(Underlying data/doc + salt)
+  currentHash: String,
+  salt: String, 
+
+  // On-chain location
+  commitmentLocation: {
+    shieldAddress: String,
+    leafIndex: Number,
+    blockNumber: Number
+  }
+
+  // Values needed for verification
+  commitmentDetails: {
+    value: String,
+    proof: Number[],
+    publicInputs: String[],
+  }
+
+}
+```

--- a/core/persistence/README.md
+++ b/core/persistence/README.md
@@ -12,46 +12,4 @@ You can build the package locally with `npm run build`.
 
 ## Baseline State Tracking
 
-```typescript
-BaselineState: {
-  
-  // Underlying document identification and location information
-  offchainLocation: {
-    dbUrl: String,
-    collectionName: String,
-    documentId: String, // UUID,
-    baselinedFields: String[],
-  }
-
-  // Counter-parties
-  counterParties: [{
-    messagingEndpoint: String,
-    name: String,
-    currentHash: String
-  }],
-
-  // Possible states:
-  // 1: based: currentHash === on-chain commitment
-  // 2. debased: currentHash !== on-chain commitment
-  currentState: String,
-  
-  // currentHash = H(Underlying data/doc + salt)
-  currentHash: String,
-  salt: String, 
-
-  // On-chain location
-  commitmentLocation: {
-    shieldAddress: String,
-    leafIndex: Number,
-    blockNumber: Number
-  }
-
-  // Values needed for verification
-  commitmentDetails: {
-    value: String,
-    proof: Number[],
-    publicInputs: String[],
-  }
-
-}
-```
+Import and use `@baseline-protocol/types/BaselineState` to help track the status of baselined documents and data fields.

--- a/core/persistence/README.md
+++ b/core/persistence/README.md
@@ -12,4 +12,4 @@ You can build the package locally with `npm run build`.
 
 ## Baseline State Tracking
 
-To help track the status of baselined documents and data fields: `import { BaselineState } from @baseline-protocol/types`
+To help track the status of baselined documents and data fields: `import { State } from @baseline-protocol/types`

--- a/core/persistence/README.md
+++ b/core/persistence/README.md
@@ -12,4 +12,4 @@ You can build the package locally with `npm run build`.
 
 ## Baseline State Tracking
 
-Import and use `@baseline-protocol/types/BaselineState` to help track the status of baselined documents and data fields. 
+To help track the status of baselined documents and data fields: `import { BaselineState } from @baseline-protocol/types`

--- a/core/persistence/README.md
+++ b/core/persistence/README.md
@@ -12,4 +12,4 @@ You can build the package locally with `npm run build`.
 
 ## Baseline State Tracking
 
-Import and use `@baseline-protocol/types/BaselineState` to help track the status of baselined documents and data fields.
+Import and use `@baseline-protocol/types/BaselineState` to help track the status of baselined documents and data fields. 

--- a/core/types/package.json
+++ b/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baseline-protocol/types",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Baseline core types",
   "license": "CC0 1.0 Universal",
   "main": "./dist/cjs/index.js",

--- a/core/types/src/index.ts
+++ b/core/types/src/index.ts
@@ -1,2 +1,3 @@
 export * from './logger';
 export * from './protocol';
+export * from './persistence';

--- a/core/types/src/persistence.ts
+++ b/core/types/src/persistence.ts
@@ -1,0 +1,33 @@
+export type BaselineCommitment = {
+  // currentHash = H(Underlying data/doc + salt)
+  salt: string;
+  // Values needed for verification (Shield.verifyAndPush inputs)
+  value: string;
+  proof: number[];
+  publicInputs: string[];
+  signatures: object;
+};
+
+export type BaselineState = {
+
+  identifier: string; // workflow identifier
+  shield: string; // Shield contract address
+
+  // Underlying document identification and location information
+  persistence: {
+    url: string;
+    model: string; // i.e. collection, table
+    id: string; // identifier, i.e. document name, UUID, primary key
+    fields: string[] | string; // fields within document to hash and baseline
+  };
+
+  // Counter-parties plus self
+  parties: [{
+    address: string; // Can use this to lookup messagingEndpoint, etc.
+    metadata: object;
+  }];
+
+  // commitments[0] is latest commitment (new commitments are prepended to array)
+  commitments: BaselineCommitment[];
+
+};

--- a/core/types/src/persistence.ts
+++ b/core/types/src/persistence.ts
@@ -1,4 +1,4 @@
-export type BaselineCommitment = {
+export type Commitment = {
   // currentHash = H(Underlying data/doc + salt)
   salt: string;
   // Values needed for verification (Shield.verifyAndPush inputs)
@@ -6,6 +6,7 @@ export type BaselineCommitment = {
   proof: number[];
   publicInputs: string[];
   signatures: object; // Allows mapping from participant address -> signature
+  metadata: object;
   sender: string; // Address of participant who created the commitment
 };
 
@@ -14,7 +15,7 @@ export type Participant = {
   metadata: object;
 }
 
-export type BaselineState = {
+export type State = {
 
   identifier: string; // workflow identifier
   shield: string; // Shield contract address
@@ -32,6 +33,6 @@ export type BaselineState = {
   parties: Participant[];
 
   // commitments[0] is latest commitment (new commitments are prepended to array)
-  commitments: BaselineCommitment[];
+  commitments: Commitment[];
 
 };

--- a/core/types/src/persistence.ts
+++ b/core/types/src/persistence.ts
@@ -5,8 +5,14 @@ export type BaselineCommitment = {
   value: string;
   proof: number[];
   publicInputs: string[];
-  signatures: object;
+  signatures: object; // Allows mapping from participant address -> signature
+  sender: string; // Address of participant who created the commitment
 };
+
+export type Participant = {
+  address: string; // Can use this to lookup messagingEndpoint, etc.
+  metadata: object;
+}
 
 export type BaselineState = {
 
@@ -19,13 +25,11 @@ export type BaselineState = {
     model: string; // i.e. collection, table
     id: string; // identifier, i.e. document name, UUID, primary key
     fields: string[] | string; // fields within document to hash and baseline
+    metadata: object;
   };
 
   // Counter-parties plus self
-  parties: [{
-    address: string; // Can use this to lookup messagingEndpoint, etc.
-    metadata: object;
-  }];
+  parties: Participant[];
 
   // commitments[0] is latest commitment (new commitments are prepended to array)
   commitments: BaselineCommitment[];

--- a/core/types/src/protocol.ts
+++ b/core/types/src/protocol.ts
@@ -16,7 +16,7 @@ export enum PayloadType {
 
 export type Message = {
   opcode: Opcode; // up to 40 bits
-  sender: string, // up to 336 bits
+  sender: string; // up to 336 bits
   recipient: string; // up to 336 bits
   shield: string; // up to 336 bits
   identifier: string; // up to 288 bits (i.e., UUIDv4 circuit/workflow identifier)


### PR DESCRIPTION
# Description

In order for a baseline stack to be able to report the status of commitments for baselined docs/data fields, we need to store relevant BaselineState information for each baselined document. This PR initializes the data structure needed to track the BaselineState, and adds that data object to the @baseline-protocol/types package so that it can be used by any other packages.

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
