### PR TITLE
up/OrgRegistry: Use structs for interface addresses

### DIFF
--- a/core/contracts/contracts/registry/OrgRegistry.sol
+++ b/core/contracts/contracts/registry/OrgRegistry.sol
@@ -30,7 +30,9 @@ contract OrgRegistry is Ownable, ERC165Compatible, Registrar, IOrgRegistry {
     }
 
     mapping (address => Org) orgMap;
-    mapping (uint => OrgInterfaces) orgInterfaceMap;
+
+    OrgInterfaces[] public orgInterfaces;
+
     uint orgInterfaceCount;
 
     Org[] public orgs;
@@ -180,11 +182,13 @@ contract OrgRegistry is Ownable, ERC165Compatible, Registrar, IOrgRegistry {
         address _shieldAddress,
         address _verifierAddress
     ) external onlyOwner returns (bool) {
-        orgInterfaceMap[orgInterfaceCount] = OrgInterfaces(
-            _groupName,
-            _tokenAddress,
-            _shieldAddress,
-            _verifierAddress
+        orgInterfaces.push(
+            OrgInterfaces(
+                _groupName,
+                _tokenAddress,
+                _shieldAddress,
+                _verifierAddress
+            )
         );
       
         orgInterfaceCount++;
@@ -218,29 +222,14 @@ contract OrgRegistry is Ownable, ERC165Compatible, Registrar, IOrgRegistry {
 
     /// @notice Function to get organization's interface details
     function getInterfaceAddresses() external view returns (
-        bytes32[] memory,
-        address[] memory,
-        address[] memory,
-        address[] memory
+        OrgInterfaces[] memory
     ) {
-        bytes32[] memory gName = new bytes32[](orgInterfaceCount);
-        address[] memory tfAddress = new address[](orgInterfaceCount);
-        address[] memory sAddress = new address[](orgInterfaceCount);
-        address[] memory vrAddress = new address[](orgInterfaceCount);
+        OrgInterfaces[] memory _orgInterfaces = new OrgInterfaces[](orgInterfaceCount);
 
         for (uint i = 0; i < orgInterfaceCount; i++) {
-            OrgInterfaces storage orgInterfaces = orgInterfaceMap[i];
-            gName[i] = orgInterfaces.groupName;
-            tfAddress[i] = orgInterfaces.tokenAddress;
-            sAddress[i] = orgInterfaces.shieldAddress;
-            vrAddress[i] = orgInterfaces.verifierAddress;
+            _orgInterfaces[i] = orgInterfaces[i];
         }
-        return (
-            gName,
-            tfAddress,
-            sAddress,
-            vrAddress
-        );
+        return _orgInterfaces;
     }
 }
 


### PR DESCRIPTION
Also:
 - replace orgInterfacesMap with orgIntefaces (array of struct OrgInterfaces)
 - modify registerInterfaces accordingly
 - modify relevant test so it passes

Ref: #264

# Description

Make changes suggested in the relevant issue, outlined in the list above.

## Related Issue
#264 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

It's easier to use a clearly defined struct with good member names than a list of bytes32/address arrays.

## How Has This Been Tested

Using `npm run test` (had to modify 1 relevant case)

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
