### PR TITLE
Update core persistence and privacy types

### DIFF
--- a/core/types/package.json
+++ b/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baseline-protocol/types",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Baseline core types",
   "license": "CC0 1.0 Universal",
   "main": "./dist/cjs/index.js",

--- a/core/types/src/index.ts
+++ b/core/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from './logger';
-export * from './protocol';
 export * from './persistence';
+export * from './privacy';
+export * from './protocol';

--- a/core/types/src/privacy.ts
+++ b/core/types/src/privacy.ts
@@ -1,0 +1,22 @@
+export type Circuit = {
+  id: string;
+  name: string;
+  description?: string;
+  type?: string;
+  provider: string;
+  curve?: string;
+  constraintSystem?: string;
+  metadata?: object;
+}
+
+export type Commitment = {
+  metadata: object; // arbitrary data
+  location: number;
+  salt: string; // salt such that currentHash = H(data + salt)
+  proof: number[];
+  publicInputs: string[];
+  sender: string; // address of participant who created the commitment
+  signatures: object; // allows mapping from participant address -> signature
+  timestamp: number; // unix timestamp when the commitment was pushed
+  value: string; // commitment value
+}


### PR DESCRIPTION
# Description

Update the core `types` package to support more robust modeling of multiparty baseline workgroups and workflows.

This PR sets the stage for a follow-on PR which will add an initial in-memory provider implementation to the core `persistence` package.

## Related Issue

- Microsoft Excel persistence package hackathon challenge -- this PR will make it more clear how a plugin can be defined to work with the core persistence package.

## Motivation and Context

The baseline standards initiative needs more clearly articulated data models. Developers need to be able to see how, for example, an Excel persistence provider could be created.