### PR TITLE
Commit-mgr updates

### DIFF
--- a/examples/bri-2/commit-mgr/.dockerignore
+++ b/examples/bri-2/commit-mgr/.dockerignore
@@ -1,0 +1,11 @@
+
+# ignore .git and .cache folders
+.git
+.cache
+
+logs
+node_modules
+npm-debug.log
+
+tests
+.env*

--- a/examples/bri-2/commit-mgr/Dockerfile
+++ b/examples/bri-2/commit-mgr/Dockerfile
@@ -1,23 +1,25 @@
-FROM node:12.16
+FROM node:12.16-alpine AS build
 
-ENV FORCE_COLOR=1
-
-RUN mkdir /app
 WORKDIR /app
-
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
 COPY package*.json ./
-COPY ts*.json ./
-
 # Install packages
-RUN npm install
+RUN npm ci
 
 # Bundle app source
 # See ignore for exclusions
 COPY . .
+RUN npm run tsc
+RUN npm ci --production
 
+FROM alpine:3
+RUN apk add nodejs --no-cache
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+
+# Start
+CMD [ "node", "./dist/index.js" ]
 EXPOSE 4001
-
-CMD [ "npm", "start" ]

--- a/examples/bri-2/commit-mgr/README.md
+++ b/examples/bri-2/commit-mgr/README.md
@@ -50,10 +50,9 @@ The `commit-mgr` service implements and processes the baseline JSON-RPC methods:
 | `baseline_getTracked` | | Retrieve a list of the shield contract addresses being tracked and persisted |
 | `baseline_verifyAndPush` | sender, address, proof, publicInputs, commit | Inserts a single commit in a tree for a given shield contract address |
 | `baseline_track` | address | Initialize a merkle tree database for the given shield contract address |
-| `baseline_untrack` | address | Remove event listeners for a given shield contract address |
+| `baseline_untrack` | address, prune? | Remove event listeners for a given shield contract address |
 | `baseline_verify` | address, value, proof | Verify a proof for a given root and commit value |
 
 ## TODO
 
-- Reduce `commit-mgr` docker image size
 - Convert all javascript files to typescript

--- a/examples/bri-2/commit-mgr/src/blockchain/events.js
+++ b/examples/bri-2/commit-mgr/src/blockchain/events.js
@@ -39,9 +39,9 @@ export const subscribeMerkleEvents = (contractAddress) => {
     logger.info(`New on-chain root: ${onchainRoot}`);
 
     const leaf = {
-      value: leafValue,
+      hash: leafValue,
       leafIndex: leafIndex,
-      transactionHash: result.transactionHash,
+      txHash: result.transactionHash,
       blockNumber: result.blockNumber
     }
     await insertLeaf(contractAddress, leaf);

--- a/examples/bri-2/commit-mgr/src/blockchain/utils.js
+++ b/examples/bri-2/commit-mgr/src/blockchain/utils.js
@@ -92,9 +92,9 @@ export const checkChainLogs = async (contractAddress, fromBlock) => {
     logger.info(`Found previously missed leaf index ${leafIndex} of value ${leafValue}`);
 
     const leaf = {
-      value: leafValue,
+      hash: leafValue,
       leafIndex: leafIndex,
-      transactionHash: logs[i].transactionHash,
+      txHash: logs[i].transactionHash,
       blockNumber: logs[i].blockNumber
     }
     await insertLeaf(contractAddress, leaf);

--- a/examples/bri-2/commit-mgr/src/db/models/MerkleTree.js
+++ b/examples/bri-2/commit-mgr/src/db/models/MerkleTree.js
@@ -31,8 +31,8 @@ const merkleTreeSchema = new Schema(
       _id: false,
       leafIndex: Number, // Only used for leaves
       blockNumber: Number, // Only used for leaves
-      transactionHash: String, // Only used for leaves
-      value: String // hash
+      txHash: String, // Only used for leaves
+      hash: String // commitment value
     }],
   },
   { versionKey: false }

--- a/examples/bri-2/commit-mgr/src/merkle-tree/index.js
+++ b/examples/bri-2/commit-mgr/src/merkle-tree/index.js
@@ -36,10 +36,10 @@ async function getPathByLeafIndex(merkleId, leafIndex) {
     const localIndex = nodeIndex % config.BUCKET_SIZE;
     let node = {
       nodeIndex,
-      value: config.ZERO
+      hash: config.ZERO
     }
     if (nodes[localIndex]) {
-      node.value = nodes[localIndex].value
+      node.hash = nodes[localIndex].hash
     }
     // insert the node into the nodes array:
     pathNodes.push(node);
@@ -76,12 +76,12 @@ async function getSiblingPathByLeafIndex(merkleId, leafIndex) {
     const localIndex = nodeIndex % config.BUCKET_SIZE;
     let node = {
       nodeIndex,
-      value: config.ZERO
+      hash: config.ZERO
     }
     // Check whether some nodeIndices don't yet exist in the db. 
     // If they don't, we'll presume their values are zero, and add these to the 'nodes' before returning them.
     if (nodes[localIndex]) {
-      node.value = nodes[localIndex].value
+      node.hash = nodes[localIndex].hash
     }
     // insert the node into the nodes array:
     siblingNodes.push(node);
@@ -126,7 +126,7 @@ async function updateTree(merkleId) {
     let { frontier } = latestRecalculation;
     frontier = frontier === undefined ? [] : frontier;
     const leaves = await getLeavesByLeafIndexRange(merkleId, fromLeafIndex, toLeafIndex);
-    const leafValues = leaves.map(leaf => leaf.value);
+    const leafValues = leaves.map(leaf => leaf.hash);
 
     logger.debug(`found leaves: %o`, leaves);
     logger.debug(`leafValues: %o`, leafValues);

--- a/examples/bri-2/commit-mgr/src/merkle-tree/utils.js
+++ b/examples/bri-2/commit-mgr/src/merkle-tree/utils.js
@@ -161,7 +161,7 @@ async function updateNodes(merkleId, frontier, leafValues, currentLeafCount) {
 
       // update the newNodes array
       const node = {
-        value: nodeValue,
+        hash: nodeValue,
         nodeIndex,
       };
       logger.debug(`Updated node: %o`, node);
@@ -193,7 +193,7 @@ async function updateNodes(merkleId, frontier, leafValues, currentLeafCount) {
 
     // update the newNodes array
     const node = {
-      value: nodeIndex === 0 ? nodeValueFull : nodeValue, // we can add the full 32-byte root (nodeIndex=0) to the db, because it doesn't need to fit into another hash round.
+      hash: nodeIndex === 0 ? nodeValueFull : nodeValue, // we can add the full 32-byte root (nodeIndex=0) to the db, because it doesn't need to fit into another hash round.
       nodeIndex,
     };
     logger.debug(`Updated node: %o`, node);

--- a/examples/bri-2/commit-mgr/tests/jsonrpc.test.js
+++ b/examples/bri-2/commit-mgr/tests/jsonrpc.test.js
@@ -49,7 +49,7 @@ beforeAll(async () => {
   //const waitTx = web3provider.bind(this, waitRelayTx);
   if (txManager === 'infura-gas') {
     const balance = await getBalance();
-    console.log('balance:', balance);
+    console.log('ITX balance:', balance);
     if (balance < 1) {
       const res = await deposit();
       console.log('deposit res:', res);
@@ -674,7 +674,7 @@ describe("Error checks", () => {
       id: 1,
     });
     expect(res.statusCode).toEqual(200);
-    const txHash = res.body.result.txHash;
+    const txHash = res.body.result ? res.body.result.txHash : undefined;
 
     if (txManager === 'besu') {
       // error occurs on internal "eth_estimateGas"

--- a/examples/bri-2/commit-mgr/tests/utils.js
+++ b/examples/bri-2/commit-mgr/tests/utils.js
@@ -23,7 +23,7 @@ const waitRelayTx = async function (relayTxHash) {
     for (let i = 0; i < statusResponse.length; i++) {
       const hashes = statusResponse[i]
       const receipt = await web3provider.getTransactionReceipt(hashes['ethTxHash'])
-      if (receipt && receipt.confirmations && receipt.confirmations >= 1) {
+      if (receipt && receipt.confirmations && receipt.confirmations > 1) {
         mined = true
         return receipt
       }

--- a/examples/bri-2/docker-compose.yml
+++ b/examples/bri-2/docker-compose.yml
@@ -75,8 +75,6 @@ services:
       - ./commit-mgr/.env
     environment:
       - DATABASE_HOST=alice-mongo:27017
-      - ETH_CLIENT_HTTP=http://alice-besu:8545
-      - ETH_CLIENT_WS=ws://alice-besu:8545
     networks:
       - alice
     ports:


### PR DESCRIPTION
# Description

Improvements/updates for the `commit-mgr` service inside bri-2:

* Improve reliability of `infura-gas` (ITX) test suite
* Reduce `commit-mgr` docker image size (1.3gb --> 72mb)
* Update service to reflect latest changes in IBaselineRPC (methods, params, etc)
* Update test suite based on IBaselineRPC changes

## How Has This Been Tested

Inside `bri-2/commit-mgr`: `npm run test`

Tested against the following ethereum client types:
* ganache
* private besu
* Infura (classic API)
* Infura gas service (ITX)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
