### PR TITLE
Utilize zokrates-js/node build variant

### DIFF
--- a/core/privacy/src/zkp/index.ts
+++ b/core/privacy/src/zkp/index.ts
@@ -1,7 +1,7 @@
 import { Circuit } from '@baseline-protocol/types';
 import { provideServiceFactory } from './provide';
 import { zokratesServiceFactory } from './zokrates';
-import { VerificationKey } from 'zokrates-js';
+import { VerificationKey } from 'zokrates-js/node';
 
 export const zkSnarkCircuitProviderServiceProvide = 'provide';
 export const zkSnarkCircuitProviderServiceZokrates = 'zokrates';

--- a/core/privacy/src/zkp/zokrates.ts
+++ b/core/privacy/src/zkp/zokrates.ts
@@ -1,4 +1,4 @@
-import { initialize, ResolveCallback, ZoKratesProvider, VerificationKey } from 'zokrates-js';
+import { initialize, ResolveCallback, ZoKratesProvider, VerificationKey } from 'zokrates-js/node';
 import { IZKSnarkCircuitProvider, IZKSnarkCompilationArtifacts, IZKSnarkWitnessComputation, IZKSnarkTrustedSetupArtifacts } from '.';
 import { readFileSync } from 'fs';
 import { v4 as uuid } from 'uuid';


### PR DESCRIPTION
Co-authored-by: myronrotter <myronrotter01@t-online.de>

# Description

<!--- Describe your changes in detail -->
Usage of the privacy package `@baseline-protocol/privacy` for Node.js applications fails due to the fact that `zokrates-js` uses the bundler variant leveraging ES2016 features by default.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#224

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
One acceptance criteria of #224 consists of refactoring the existing the codebase to import and use `@baseline-protocol/privacy`.
However, importing mentioned package fails with the error

```
import wrapper from './wrapper.js';
       ^^^^^^^

SyntaxError: Unexpected identifier
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Module._compile (/home/minh/baseline/examples/radish34/zkp/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Object.newLoader [as .js] (/home/minh/baseline/examples/radish34/zkp/node_modules/pirates/lib/index.js:104:7)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/home/minh/baseline/examples/radish34/zkp/node_modules/@baseline-protocol/privacy/src/zkp/zokrates.ts:1:1)
```

When refactoring the privacy package to use `zokrates-js/node` instead of `zokrates-js`, this error gets resolved. This variant uses `require` instead of `import` in the entrypoint, making `zokrates-js/node` a valid CommonJS package. See https://zokrates.github.io/toolbox/zokrates_js.html#importing for more information.

## Result

Node.js applications should now be able to use `@baseline-protocol/privacy` out-of-the-box without adding a transpilation step like Typescript or Babel, including the radish34 demo project.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The following steps were made:
* passing all tests using `npm test` in the privacy package
* running `npm run build` successfully
* importing the privacy package locally in a Node.js project is successful

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
