### PR TITLE
Add zokrates-cli-wrapper as privacy provider

### DIFF
--- a/core/privacy/docker-compose.yml
+++ b/core/privacy/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  zokrates-cli-wrapper:
+    build:
+      context: ./
+      dockerfile: ./ops/zokrates-cli-wrapper.Dockerfile
+    restart: on-failure
+    volumes:
+      - ../../lib:/app/lib:delegated
+      - ./src:/app/src:delegated
+      - ./test:/app/test:delegated
+    command: tail -F /dev/null

--- a/core/privacy/ops/zokrates-cli-wrapper.Dockerfile
+++ b/core/privacy/ops/zokrates-cli-wrapper.Dockerfile
@@ -1,0 +1,15 @@
+FROM zokrates/zokrates:0.6.3 as builder
+FROM node:14
+
+ENV ZOKRATES_BIN=/app/zokrates
+ENV ZOKRATES_STDLIB=/app/stdlib
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=builder /home/zokrates/.zokrates/bin/zokrates $ZOKRATES_BIN
+COPY --from=builder /home/zokrates/.zokrates/stdlib $ZOKRATES_STDLIB
+
+COPY package*.json tsconfig*.json jest.config.js ./
+
+RUN npm ci

--- a/core/privacy/package-lock.json
+++ b/core/privacy/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@baseline-protocol/privacy",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -34,6 +34,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@baseline-protocol/types/-/types-1.1.0.tgz",
       "integrity": "sha512-hrWiGqvkhgM8vMaMABIxGbzyJlvCLJBbPcXJIrw2E+M5ieH1TgZGW0/EozXO/oeeepMlH9MaeU6Jlhalro/bqg=="
+    },
+    "@dingomacaroni/zokrates.js": {
+      "version": "1.3.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dingomacaroni/zokrates.js/-/zokrates.js-1.3.0-alpha.2.tgz",
+      "integrity": "sha512-E/oRLMOI4UGg19cctGKgmL9zRzhKg4QLVxUbYhY+qN771wLhtFtjaitIeatSy6X7avQwk4uj+5BEcr3SQwHb0Q=="
     },
     "@fimbul/bifrost": {
       "version": "0.21.0",

--- a/core/privacy/package.json
+++ b/core/privacy/package.json
@@ -14,10 +14,12 @@
     "build:umd": "webpack",
     "build": "npm run clean && npm run build:cjs && npm run build:umd",
     "clean": "rm -rf ./dist",
-    "test": "./node_modules/.bin/mocha --require esm --require ts-node/register --require global-jsdom/lib/register test/**/*.spec.ts --timeout 30000000000 --unhandled-rejections=strict --max-old-space-size=8192"
+    "test": "./node_modules/.bin/mocha --require esm --require ts-node/register --require global-jsdom/lib/register test/**/*.spec.ts --exclude test/zokrates-cli-wrapper.spec.ts --timeout 30000000000 --unhandled-rejections=strict --max-old-space-size=8192 && npm run test:zokrates-cli-wrapper",
+    "test:zokrates-cli-wrapper": "docker-compose run zokrates-cli-wrapper ./node_modules/.bin/mocha --require esm --require ts-node/register --require global-jsdom/lib/register test/zokrates-cli-wrapper.spec.ts --timeout 30000000000 --unhandled-rejections=strict --max-old-space-size=8192"
   },
   "dependencies": {
     "@baseline-protocol/types": "1.1.0",
+    "@dingomacaroni/zokrates.js": "^1.3.0-alpha.2",
     "@types/uuid": "^8.0.0",
     "big-integer": "^1.6.48",
     "hex-to-binary": "^1.0.1",

--- a/core/privacy/src/index.ts
+++ b/core/privacy/src/index.ts
@@ -9,4 +9,5 @@ export {
   zkSnarkCircuitProviderServiceFactory,
   zkSnarkCircuitProviderServiceProvide,
   zkSnarkCircuitProviderServiceZokrates,
+  zkSnarkCircuitProviderServiceZokratesCliWrapper
 } from './zkp';

--- a/core/privacy/src/zkp/index.ts
+++ b/core/privacy/src/zkp/index.ts
@@ -1,10 +1,12 @@
 import { Circuit } from '@baseline-protocol/types';
 import { provideServiceFactory } from './provide';
 import { zokratesServiceFactory } from './zokrates';
+import { zokratesCliWrapperServiceFactory } from './zokrates-cli-wrapper';
 import { VerificationKey } from 'zokrates-js';
 
 export const zkSnarkCircuitProviderServiceProvide = 'provide';
 export const zkSnarkCircuitProviderServiceZokrates = 'zokrates';
+export const zkSnarkCircuitProviderServiceZokratesCliWrapper = 'zokrates-cli-wrapper';
 
 export interface ICircuitProver {
   prove(circuitId: any, params: any): Promise<any>;
@@ -61,6 +63,9 @@ export async function zkSnarkCircuitProviderServiceFactory(
       break;
     case zkSnarkCircuitProviderServiceZokrates:
       service = await zokratesServiceFactory(config);
+      break;
+    case zkSnarkCircuitProviderServiceZokratesCliWrapper:
+      service = await zokratesCliWrapperServiceFactory(config);
       break;
     default:
       throw new Error('zkSnark circuit provider service required');

--- a/core/privacy/src/zkp/zokrates-cli-wrapper.ts
+++ b/core/privacy/src/zkp/zokrates-cli-wrapper.ts
@@ -1,0 +1,224 @@
+import { IZKSnarkCircuitProvider, IZKSnarkCompilationArtifacts, IZKSnarkWitnessComputation, IZKSnarkTrustedSetupArtifacts, IZKSnarkTrustedSetupKeypair } from '.';
+import { compile, computeWitness, exportVerifier, generateProof, setup } from '@dingomacaroni/zokrates.js';
+import { VerificationKey } from 'zokrates-js';
+import { existsSync, lstatSync, mkdirSync, writeFileSync, readFileSync, unlink } from 'fs';
+import { v4 as uuid } from 'uuid';
+
+// NOTE: location for ZoKrates bin should be defined in the Dockerfile
+// NOTE: location for ZoKrates stdlib should be defined in the Dockerfile
+const defaultPath = '/app/zok/';
+
+// NOTE: defaults exactly similar to zokrates.ts provider
+const defaultCurve = 'bn128';
+const defaultBackend = 'bellman';
+const defaultProvingScheme = 'g16';
+const defaultSolidityAbi = 'v2';
+
+const deleteFile = (fileName) => {
+  unlink(fileName, error => {
+    if (error) throw error;
+  });
+}
+
+export class ZoKratesCliWrapperService implements IZKSnarkCircuitProvider {
+
+  private path: string;
+  private curve: string;
+  private backend: string;
+  private provingScheme: string;
+  private solidityAbi: string;
+
+  constructor(
+    path: string,
+    curve: string,
+    backend: string,
+    provingScheme: string,
+    solidityAbi: string
+  ) {
+    // NOTE: path must start from Dockerfile WORKDIR
+    this.path = path;
+    this.curve = curve;
+    this.backend = backend;
+    this.provingScheme = provingScheme;
+    this.solidityAbi = solidityAbi;
+
+    // Ensure path ends with /
+    path = path.endsWith('/') ? path : `${path}/`;
+
+    // Check if path exists and is directory, otherwise create
+    if (!existsSync(path) || !lstatSync(path).isDirectory()) {
+      mkdirSync(path, { recursive: true });
+    }
+  }
+
+  async compile(source: string, location: string): Promise<IZKSnarkCompilationArtifacts> {
+    // NOTE: location is not used, ZoKrates cli and therefore ZoKrates Node.js wrapper @dingomacaroni/zokrates.js assumes main as default location
+    // NOTE: may improve performance using async instead of sync read/write
+    return new Promise(async (resolve, reject) => {
+      try {
+        // Write source to file
+        const timestamp = Date.now();
+        writeFileSync(`${this.path}${timestamp}.zok`, source);
+
+        // Compile zok file
+        await compile(`${this.path}${timestamp}.zok`, this.path, `${timestamp}`, `${timestamp}_abi.json`, this.curve);
+
+        // Read files
+        const compilationArtifacts: IZKSnarkCompilationArtifacts = {
+          program: readFileSync(`${this.path}${timestamp}`),
+          abi: JSON.stringify(JSON.parse(readFileSync(`${this.path}${timestamp}_abi.json`).toString()))
+        }
+
+        // Clean
+        deleteFile(`${this.path}${timestamp}.zok`);
+        deleteFile(`${this.path}${timestamp}.ztf`);
+        deleteFile(`${this.path}${timestamp}`);
+        deleteFile(`${this.path}${timestamp}_abi.json`);
+
+        resolve(compilationArtifacts);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  async computeWitness(artifacts: IZKSnarkCompilationArtifacts, args: any[]): Promise<IZKSnarkWitnessComputation> {
+    return new Promise(async (resolve, reject) => {
+      try {
+        // Write program bin and abi to file
+        const timestamp = Date.now();
+        writeFileSync(`${this.path}${timestamp}`, artifacts.program);
+        writeFileSync(`${this.path}${timestamp}_abi.json`, artifacts.abi);
+
+        // Compute witness
+        const cliOutput = await computeWitness(`${this.path}${timestamp}`, `${this.path}${timestamp}_abi.json`, this.path, `${timestamp}_witness`, args, {verbose: true});
+
+        // HACK: Parse witness.output from cli verbose output, since cli does not write it to file
+        /*
+        'Computing witness...\n' +
+        'def main(_0) -> (1):\n' +
+        '\t(1 * _0) * (1 * _0) == 1 * _1\n' +
+        '\t(1 * ~one) * (1 * _1) == 1 * ~out_0\n' +
+        '\t return ~out_0\n' +
+        '\n' +
+        'Witness: \n' +
+        '\n' +
+        '["4"]\n'
+        */
+        const indexAtWitnessStr = cliOutput.search('Witness:');
+        const indexAfterWitnessStr = indexAtWitnessStr + 'Witness:'.length;
+        const output = cliOutput.substring(indexAfterWitnessStr, cliOutput.length);
+        const parsedOutput = output.trim();
+
+        // Read file
+        const witness: IZKSnarkWitnessComputation = {
+          witness: readFileSync(`${this.path}${timestamp}_witness`).toString(),
+          output: parsedOutput
+        }
+
+        // Clean
+        deleteFile(`${this.path}${timestamp}`);
+        deleteFile(`${this.path}${timestamp}_abi.json`);
+        deleteFile(`${this.path}${timestamp}_witness`);
+
+        resolve(witness);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  async exportVerifier(verifyingKey: VerificationKey): Promise<string> {
+    return new Promise(async (resolve, reject) => {
+      try {
+        // Write vk to file
+        const timestamp = Date.now();
+        //writeFileSync(`${this.path}${timestamp}_vk.key`, JSON.stringify(verifyingKey, null, '  '));
+        writeFileSync(`${this.path}${timestamp}_vk.key`, JSON.stringify(verifyingKey));
+
+        // Export verifier
+        await exportVerifier(`${this.path}${timestamp}_vk.key`, this.path, `${timestamp}_verifier.sol`, this.provingScheme, this.curve, this.solidityAbi);
+
+        // Read file
+        const verifierSource = readFileSync(`${this.path}${timestamp}_verifier.sol`).toString();
+
+        // Clean
+        deleteFile(`${this.path}${timestamp}_vk.key`);
+        deleteFile(`${this.path}${timestamp}_verifier.sol`);
+
+        resolve(verifierSource);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  async generateProof(circuit: any, witness: string, provingKey: any): Promise<any> {
+    return new Promise(async (resolve, reject) => {
+      try {
+        // Write program bin, witness and proving key to file
+        const timestamp = Date.now();
+        writeFileSync(`${this.path}${timestamp}`, circuit);
+        writeFileSync(`${this.path}${timestamp}_witness`, witness);
+        writeFileSync(`${this.path}${timestamp}_pk.key`, provingKey);
+
+        // Generate proof
+        await generateProof(`${this.path}${timestamp}`, `${this.path}${timestamp}_pk.key`, `${this.path}${timestamp}_witness`, this.path, `${timestamp}_proof.json`, this.provingScheme, this.backend);
+
+        // Read file
+        const proof = JSON.parse(readFileSync(`${this.path}${timestamp}_proof.json`).toString());
+
+        // Clean
+        deleteFile(`${this.path}${timestamp}`);
+        deleteFile(`${this.path}${timestamp}_witness`);
+        deleteFile(`${this.path}${timestamp}_pk.key`);
+        deleteFile(`${this.path}${timestamp}_proof.json`);
+
+        resolve(proof);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  async setup(artifacts: IZKSnarkCompilationArtifacts): Promise<IZKSnarkTrustedSetupArtifacts> {
+    return new Promise(async (resolve, reject) => {
+      try {
+        // Write program bin and abi to file
+        const timestamp = Date.now();
+        writeFileSync(`${this.path}${timestamp}`, artifacts.program);
+        // NOTE: ABI is not used
+        writeFileSync(`${this.path}${timestamp}_abi.json`, artifacts.abi);
+
+        // Perform setup
+        await setup(`${this.path}${timestamp}`, this.path, this.provingScheme, this.backend, `${timestamp}_vk.key`, `${timestamp}_pk.key`);
+
+        // Read files
+        const keypair:IZKSnarkTrustedSetupKeypair = {
+          vk: JSON.parse(readFileSync(`${this.path}${timestamp}_vk.key`).toString()),
+          pk: readFileSync(`${this.path}${timestamp}_pk.key`)
+        }
+
+        const artifact: IZKSnarkTrustedSetupArtifacts = {
+          identifier: uuid(),
+          keypair: keypair,
+          verifierSource: await this.exportVerifier(keypair.vk),
+        };
+
+        // Clean
+        deleteFile(`${this.path}${timestamp}`);
+        deleteFile(`${this.path}${timestamp}_abi.json`);
+        deleteFile(`${this.path}${timestamp}_pk.key`);
+        deleteFile(`${this.path}${timestamp}_vk.key`);
+
+        resolve(artifact);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+}
+
+export const zokratesCliWrapperServiceFactory = async (config?: any): Promise<ZoKratesCliWrapperService> => {
+  return new ZoKratesCliWrapperService(config?.path || defaultPath, config?.curve || defaultCurve, config?.backend || defaultBackend, config?.provingScheme || defaultProvingScheme, config?.solidityAbi || defaultSolidityAbi);
+};

--- a/core/privacy/test/zokrates-cli-wrapper.spec.ts
+++ b/core/privacy/test/zokrates-cli-wrapper.spec.ts
@@ -1,0 +1,62 @@
+import { shouldBehaveLikeZKSnarkCircuit } from './shared';
+import { zkSnarkCircuitProviderServiceFactory, zkSnarkCircuitProviderServiceZokratesCliWrapper } from '../src/index';
+import { flattenDeep } from '../src/utils/conversions';
+
+const noopAgreementCircuitPath = './lib/circuits/noopAgreement.zok';
+const createAgreementPath = './lib/circuits/createAgreement.zok';
+const createAgreementOwnedPath = './lib/circuits/createAgreementOwned.zok';
+const signAgreementPath = './lib/circuits/signAgreement.zok';
+const proofOfOwnershipPath = './lib/circuits/prove-ownership-of-sk.zok';
+
+let provider;
+
+describe('when the underlying zokrates-cli-wrapper provider is available', () => {
+  beforeEach(async () => {
+    provider = await zkSnarkCircuitProviderServiceFactory(zkSnarkCircuitProviderServiceZokratesCliWrapper);
+  });
+
+  it('runs the noopAgreement circuit lifecycle successfully', () => {
+    shouldBehaveLikeZKSnarkCircuit(provider, noopAgreementCircuitPath, ['2']);
+  });
+
+  it('runs the createAgreement circuit lifecycle successfully', () => {
+    const args = [
+      '1',
+      ['3', '1'],
+      ['3', '5'],
+      ['6', '7'],
+      '8',
+      '9'
+    ]
+    shouldBehaveLikeZKSnarkCircuit(provider, createAgreementPath, flattenDeep(args));
+  });
+
+  it('runs the proof of ownership circuit lifecycle successfully', () => {
+    const args = [['1', '2'], '3'];
+    shouldBehaveLikeZKSnarkCircuit(provider, proofOfOwnershipPath, flattenDeep(args));
+  });
+
+  it('runs the createAgreementOwned circuit lifecycle successfully', () => {
+   const args = [
+    '1',
+    ['2', '3'],
+    ['4', '5'],
+    ['6', '7'],
+    ['8', '9'],
+    '10',
+    '11',
+    '12'
+   ]
+    shouldBehaveLikeZKSnarkCircuit(provider, createAgreementOwnedPath, flattenDeep(args));
+  });
+
+  it('runs the signAgreement circuit lifecycle successfully', () => {
+   const args = [
+    ['1', '2', '3', '4', '5', '6', '7', '8'],
+    ['9', '10'],
+    ['1', '2'],
+    '3',
+   ]
+    shouldBehaveLikeZKSnarkCircuit(provider, signAgreementPath, flattenDeep(args));
+  });
+});

--- a/lib/circuits/signAgreement.zok
+++ b/lib/circuits/signAgreement.zok
@@ -1,11 +1,15 @@
 import "signatures/verifyEddsa" as verifyEddsa
 import "ecc/babyjubjubParams" as context
 from "ecc/babyjubjubParams" import BabyJubJubParams
-from "./createAgreement" import Agreement
 
 struct Signature {
   field[2] R
   field S
+}
+
+struct Agreement {
+  u32[8] hash
+  field[2] senderPublicKey
 }
 
 // Receive a rawAgreement object, and verift its signature


### PR DESCRIPTION
Co-authored-by: minhi <vminhd@gmail.com>

# Description

<!--- Describe your changes in detail -->
This PR proposes the `zokrates-cli-wrapper` as a new ZoKrates based privacy provider implementing the `IZKSnarkCircuitProvider` interface. Therefore, the provider uses the `@dingomacaroni/zokrates.js` package as a Node.js wrapper for ZoKrates CLI to implement the `IZKSnarkCircuitProvider` interface.
`@dingomacaroni/zokrates.js` is a refactored fork of `@eyblockchain/zokrates.js` for ZoKrates version >= 0.6. Similar to the `@eyblockchain/zokrates.js` package, the `@dingomacaroni/zokrates.js` is meant to be used through Docker containers running a Linux OS with ZoKrates executable in-place. Currently, the package is in its alpha version but work is in progress to support Node.js >= 10 and ZoKrates version >= 0.6 with sophisticated input checking and CLI outputs.

## Related Issues and PRs

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Refer to PR #292.

## Motivation, context and advantages

<!--- Why is this change required? What problem does it solve? -->
While coming to the findings described in PR #292: 
ZoKrates privacy provider based on `zokrates-js` is limited to `bellman` as backend, `g16` as proving scheme and `bn128` as curve at the moment. Whereby, ZoKrates CLI supports various backends, curves and proving schemes, read [here](https://zokrates.github.io/toolbox/proving_schemes.html).

The proposed provider has the following advantages.

### Advantages
- `zokrates-cli-wrapper` provider is capable to use all curves, backends and proving schemes supported by the ZoKrates CLI
- this is of great interest considering g16 malleability
- enables the implementation of #224 in PR #292
- enables compilation of complex circuits, e.g. `zokrates` provider based on `zokrates-js` leads to JS heap out of memory for `signAgreement.zok` while `signAgreement.zok` compiles successfully with `zokrates-cli-wrapper`

### Requirements
- this provider is meant to be used through Docker containers running a Linux OS or any environment with ZoKrates executable and stdlib in-place

### Disadvantages
- circuits need to be self-contained, e.g. local imports will result in an I/O Error

## TODO 
- `@dingomacaroni/zokrates.js` implements required functionalities but bump `@dingomacaroni/zokrates.js` version once it is released
- `signAgreement.zok` test fails (probably due to wrong inputs (`args`) for DdDSA verification) 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In `/core/privacy`, run `npm install` followed by `npm test`.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
