### PR TITLE
refactor bri-1 tests

### DIFF
--- a/examples/bri-1/base-example/src/index.ts
+++ b/examples/bri-1/base-example/src/index.ts
@@ -855,7 +855,7 @@ export class ParticipantStack {
     })
   }
 
-  async requireWorkgroupContract(type: string, timeout: number = 15000): Promise<any> {
+  async requireWorkgroupContract(type: string): Promise<any> {
     return await tryTimes(() => this.resolveWorkgroupContract(type))
   }
 

--- a/examples/bri-1/base-example/src/index.ts
+++ b/examples/bri-1/base-example/src/index.ts
@@ -14,6 +14,28 @@ import { AuthService } from 'ts-natsutil';
 // const baselineDocumentCircuitPath = '../../../lib/circuits/createAgreement.zok';
 const baselineProtocolMessageSubject = 'baseline.proxy';
 
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+class TryError extends Error {
+  promiseErrors: any[] = []
+}
+
+const tryTimes = async <T>(prom: () => Promise<T>, times: number = 80, wait: number = 9400): Promise<T> => {
+  const errors : any[] = [];
+  for (let index = 0; index < times; index++) {
+    try {
+      return await prom()
+    } catch (err) { 
+      errors.push(err);
+    }
+    await sleep(wait);
+  }
+  const error = new TryError("Unfulfilled promises");
+  error.promiseErrors = errors;
+  throw error;
+}
+
+
 export class ParticipantStack {
 
   private baseline?: IBaselineRPC & IBlockchainService & IRegistry & IVault;
@@ -167,25 +189,25 @@ export class ParticipantStack {
             this.sendProtocolMessage(msg.sender, Opcode.Baseline, payload);
           });
         } else if (payload.signatures.length < workflowSignatories) {
-            if (payload.sibling_path && payload.sibling_path.length > 0) {
-              // perform off-chain verification to make sure this is a legal state transition
-              const root = payload.sibling_path[0];
-              const verified = this.baseline?.verify(this.contracts['shield'].address, payload.leaf, root, payload.sibling_path);
-              if (!verified) {
-                console.log('WARNING-- off-chain verification of proposed state transition failed...');
-                this.workgroupCounterparties.forEach(async recipient => {
-                  this.sendProtocolMessage(recipient, Opcode.Baseline, { err: 'verification failed' });
-                });
-                return Promise.reject('failed to verify');
-              }
+          if (payload.sibling_path && payload.sibling_path.length > 0) {
+            // perform off-chain verification to make sure this is a legal state transition
+            const root = payload.sibling_path[0];
+            const verified = this.baseline?.verify(this.contracts['shield'].address, payload.leaf, root, payload.sibling_path);
+            if (!verified) {
+              console.log('WARNING-- off-chain verification of proposed state transition failed...');
+              this.workgroupCounterparties.forEach(async recipient => {
+                this.sendProtocolMessage(recipient, Opcode.Baseline, { err: 'verification failed' });
+              });
+              return Promise.reject('failed to verify');
             }
+          }
 
-            // sign state transition
-            const signature = (await this.signMessage(vault.id!, this.babyJubJub?.id!, payload.hash)).signature;
-            payload.signatures.push(signature);
-            this.workgroupCounterparties.forEach(async recipient => {
-              this.sendProtocolMessage(recipient, Opcode.Baseline, payload);
-            });
+          // sign state transition
+          const signature = (await this.signMessage(vault.id!, this.babyJubJub?.id!, payload.hash)).signature;
+          payload.signatures.push(signature);
+          this.workgroupCounterparties.forEach(async recipient => {
+            this.sendProtocolMessage(recipient, Opcode.Baseline, payload);
+          });
         } else {
           // create state transition commitment
           payload.result = await this.generateProof('modify_state', JSON.parse(msg.payload.toString()));
@@ -210,7 +232,7 @@ export class ParticipantStack {
             this.workgroupCounterparties.forEach(async recipient => {
               await this.sendProtocolMessage(recipient, Opcode.Baseline, payload);
             });
-        } else {
+          } else {
             return Promise.reject('failed to insert leaf');
           }
         }
@@ -317,7 +339,7 @@ export class ParticipantStack {
     this.natsBearerTokens[messagingEndpoint] = invite.prvd.data.params.authorized_bearer_token;
     this.workflowIdentifier = invite.prvd.data.params.workflow_identifier;
 
-    await this.baseline?.track(invite.prvd.data.params.shield_contract_address).catch((err) => {});
+    await this.baseline?.track(invite.prvd.data.params.shield_contract_address).catch((err) => { });
     await this.registerOrganization(this.baselineConfig.orgName, this.natsConfig.natsServers[0]);
     await this.requireOrganization(await this.resolveOrganizationAddress());
     await this.sendProtocolMessage(counterpartyAddr, Opcode.Join, {
@@ -642,34 +664,23 @@ export class ParticipantStack {
   }
 
   async requireVault(token?: string): Promise<ProvideVault> {
-    let vault;
     let tkn = token;
     if (!tkn) {
       const orgToken = await this.createOrgToken();
       tkn = orgToken.accessToken || orgToken.token;
     }
 
-    let interval;
-    const promises = [] as any;
-    promises.push(new Promise<void>((resolve, reject) => {
-      interval = setInterval(async () => {
-        const vaults = await Vault.clientFactory(
-          tkn!,
-          this.baselineConfig.vaultApiScheme!,
-          this.baselineConfig.vaultApiHost!,
-        ).fetchVaults({});
-        if (vaults && vaults.length > 0) {
-          vault = vaults[0];
-          resolve();
-        }
-      }, 2500);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
-
-    return vault;
+    return await tryTimes(async () => {
+      const vaults = await Vault.clientFactory(
+        tkn!,
+        this.baselineConfig.vaultApiScheme!,
+        this.baselineConfig.vaultApiHost!,
+      ).fetchVaults({});
+      if (vaults && vaults.length > 0) {
+        return vaults[0];
+      }
+      throw new Error();
+    });
   }
 
   async signMessage(vaultId: string, keyId: string, message: string): Promise<any> {
@@ -816,79 +827,36 @@ export class ParticipantStack {
   }
 
   private async requireCapabilities(): Promise<void> {
-    let interval;
-    const promises = [] as any;
-    promises.push(new Promise<void>((resolve, reject) => {
-      interval = setInterval(async () => {
-        if (this.capabilities?.getBaselineRegistryContracts()) {
-          resolve();
-        }
-      }, 2500);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
+    return await tryTimes(async () => {
+      if (this.capabilities?.getBaselineRegistryContracts()) {
+        return;
+      }
+      throw new Error();
+    })
   }
 
   async requireOrganization(address: string): Promise<Organization> {
-    let organization;
-    let interval;
+    return await tryTimes(async () => {
+      const org = await this.fetchOrganization(address);
+      if (org && org['address'].toLowerCase() === address.toLowerCase()) {
+        return org;
+      }
 
-    const promises = [] as any;
-    promises.push(new Promise<void>((resolve, reject) => {
-      interval = setInterval(async () => {
-        this.fetchOrganization(address).then((org) => {
-          if (org && org['address'].toLowerCase() === address.toLowerCase()) {
-            organization = org;
-            resolve();
-          }
-        }).catch((err) => { });
-      }, 5000);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
-
-    return organization;
+      throw new Error();
+    })
   }
 
   async requireWorkgroup(): Promise<void> {
-    let interval;
-    const promises = [] as any;
-    promises.push(new Promise<void>((resolve, reject) => {
-      interval = setInterval(async () => {
-        if (this.workgroup) {
-          resolve();
-        }
-      }, 2500);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
+    return await tryTimes(async () => {
+      if (this.workgroup) {
+        return this.workgroup;
+      }
+      throw new Error();
+    })
   }
 
-  async requireWorkgroupContract(type: string): Promise<any> {
-    let contract;
-    let interval;
-
-    const promises = [] as any;
-    promises.push(new Promise<void>((resolve, reject) => {
-      interval = setInterval(async () => {
-        this.resolveWorkgroupContract(type).then((cntrct) => {
-          contract = cntrct;
-          resolve();
-        }).catch((err) => { });
-      }, 5000);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
-
-    return contract;
+  async requireWorkgroupContract(type: string, timeout: number = 15000): Promise<any> {
+    return await tryTimes(() => this.resolveWorkgroupContract(type))
   }
 
   async resolveWorkgroupContract(type: string): Promise<any> {

--- a/examples/bri-1/base-example/test/e2e.spec.ts
+++ b/examples/bri-1/base-example/test/e2e.spec.ts
@@ -115,8 +115,8 @@ describe('baseline', () => {
       'forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock',
     );
 
-    bobApp.init();
-    aliceApp.init();
+    await bobApp.init();
+    await aliceApp.init();
   });
 
   describe('workgroup', () => {
@@ -159,20 +159,15 @@ describe('baseline', () => {
         assert(workgroupToken, 'workgroup token should not be null');
       });
 
-      describe('workgroup initiator', function () {
-        before(async () => {
-          this.ctx.app = bobApp;
-        });
-
-        describe(`initial workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAnInitialWorkgroupOrganization.bind(this));
-        describe(`workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAWorkgroupOrganization.bind(this));
+      describe('workgroup initiator', () => {
+        describe(`initial workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAnInitialWorkgroupOrganization(() => bobApp));
+        describe(`workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAWorkgroupOrganization(() => bobApp));
       });
 
       describe('inviting participants to the workgroup', function () {
         let inviteToken;
 
         before(async () => {
-          this.ctx.app = aliceApp;
           await bobApp.inviteWorkgroupParticipant(alice.email);
           inviteToken = await scrapeInvitationToken('bob-ident-consumer'); // if configured, ident would have sent an email to Alice
         });
@@ -188,17 +183,13 @@ describe('baseline', () => {
             await aliceApp.acceptWorkgroupInvite(inviteToken, bobApp.getWorkgroupContracts());
           });
 
-          describe(`invited workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAnInvitedWorkgroupOrganization.bind(this));
-          describe(`workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupOrganization.bind(this));
-          describe(`workgroup counterparty: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupCounterpartyOrganization.bind(this));
+          describe(`invited workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAnInvitedWorkgroupOrganization(() => aliceApp));
+          describe(`workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupOrganization(() => aliceApp));
+          describe(`workgroup counterparty: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupCounterpartyOrganization(() => aliceApp));
         });
 
         describe('counterparties post-onboarding', function () {
-          before(async () => {
-            this.ctx.app = bobApp;
-          });
-
-          describe(bobCorpName, shouldBehaveLikeAWorkgroupCounterpartyOrganization.bind(this));
+          describe(bobCorpName, shouldBehaveLikeAWorkgroupCounterpartyOrganization(() => bobApp));
         });
       });
 

--- a/examples/bri-1/base-example/test/shared.ts
+++ b/examples/bri-1/base-example/test/shared.ts
@@ -1,6 +1,8 @@
 import { assert } from 'chai';
 import { ParticipantStack } from '../src';
 
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
 export const shouldBehaveLikeAWorkgroupOrganization = (getApp: () => ParticipantStack) => () => {
   describe(`organization details`, () => {
     let org;
@@ -140,11 +142,15 @@ export const shouldBehaveLikeAWorkgroupOrganization = (getApp: () => Participant
 
     describe('workflow privacy', () => {
       let circuit;
-  
+
       describe('zkSNARK circuits', () => {
         describe('synchronization', () => {
           before(async () => {
-            circuit = await getApp().getBaselineCircuit();
+            // We need to Wait fo the Sync
+            while (getApp().getBaselineCircuit() === undefined) {
+              await sleep(10000);
+            }
+            circuit = getApp().getBaselineCircuit();
             assert(circuit, 'setup artifacts should not be null');
           });
 
@@ -330,7 +336,7 @@ export const shouldBehaveLikeAnInitialWorkgroupOrganization = (getApp: () => Par
 
           it('should track the workgroup shield in an off-chain merkle tree database', async () => {
             // @ts-ignore
-            const trackedShieldContracts = await getApp().baseline.getTracked(); 
+            const trackedShieldContracts = await getApp().baseline.getTracked();
             assert(trackedShieldContracts.indexOf(shield.address.toLowerCase()) !== -1, 'workgroup shield contract should have been tracked');
           });
 

--- a/examples/bri-1/base-example/test/shared.ts
+++ b/examples/bri-1/base-example/test/shared.ts
@@ -1,11 +1,12 @@
 import { assert } from 'chai';
+import { ParticipantStack } from '../src';
 
-export const shouldBehaveLikeAWorkgroupOrganization = function () {
+export const shouldBehaveLikeAWorkgroupOrganization = (getApp: () => ParticipantStack) => () => {
   describe(`organization details`, () => {
     let org;
 
     before(async () => {
-      org = this.ctx.app.getOrganization();
+      org = getApp().getOrganization();
       assert(org, 'org should not be null');
     });
 
@@ -17,11 +18,11 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       let workflowIdentifier;
 
       before(async () => {
-        erc1820Registry = await this.ctx.app.requireWorkgroupContract('erc1820-registry');
-        orgRegistry = await this.ctx.app.requireWorkgroupContract('organization-registry');
-        shield = this.ctx.app.getWorkgroupContract('shield');
-        verifier = this.ctx.app.getWorkgroupContract('verifier');
-        workflowIdentifier = this.ctx.app.getWorkflowIdentifier();
+        erc1820Registry = await getApp().requireWorkgroupContract('erc1820-registry');
+        orgRegistry = await getApp().requireWorkgroupContract('organization-registry');
+        shield = getApp().getWorkgroupContract('shield');
+        verifier = getApp().getWorkgroupContract('verifier');
+        workflowIdentifier = getApp().getWorkflowIdentifier();
       });
 
       it('should have a local reference to the on-chain ERC1820 registry contract', async () => {
@@ -40,7 +41,8 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       });
 
       it('should track the workgroup shield in an off-chain merkle tree database', async () => {
-        const trackedShieldContracts = await this.ctx.app.baseline.getTracked();
+        // @ts-ignore
+        const trackedShieldContracts = await getApp().baseline.getTracked();
         assert(trackedShieldContracts.indexOf(shield.address.toLowerCase()) !== -1, 'workgroup shield contract should have been tracked');
       });
 
@@ -59,8 +61,8 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       let natsSubscriptions;
 
       before(async () => {
-        natsService = this.ctx.app.getMessagingService();
-        natsSubscriptions = this.ctx.app.getProtocolSubscriptions();
+        natsService = getApp().getMessagingService();
+        natsSubscriptions = getApp().getProtocolSubscriptions();
       });
 
       it('should have an established NATS connection', async () => {
@@ -78,7 +80,7 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       let address;
 
       before(async () => {
-        const keys = await this.ctx.app.fetchKeys();
+        const keys = await getApp().fetchKeys();
         address = keys && keys.length >= 3 ? keys[2].address : null;
         assert(address, 'default secp256k1 keypair should not be null');
       });
@@ -88,12 +90,12 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       });
 
       it('should register the organization in the on-chain registry using its default secp256k1 address', async () => {
-        const org = await this.ctx.app.requireOrganization(address);
+        const org = await getApp().requireOrganization(address);
         assert(org, 'org should be present in on-chain registry');
       });
 
       it('should associate the organization with the local workgroup', async () => {
-        const orgs = await this.ctx.app.fetchWorkgroupOrganizations();
+        const orgs = await getApp().fetchWorkgroupOrganizations();
         assert(orgs.length === 1, 'workgroup should have associated org');
       });
     });
@@ -103,12 +105,12 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       let keys;
 
       before(async () => {
-        keys = await this.ctx.app.fetchKeys();
+        keys = await getApp().fetchKeys();
         address = keys && keys.length >= 3 ? keys[2].address : null;
       });
 
       it('should create a default vault for the organization', async () => {
-        const vaults = await this.ctx.app.fetchVaults();
+        const vaults = await getApp().fetchVaults();
         assert(vaults.length === 1, 'default vault not created');
       });
 
@@ -127,7 +129,7 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       });
 
       it('should resolve the created secp256k1 keypair as the organization address', async () => {
-        const addr = await this.ctx.app.resolveOrganizationAddress();
+        const addr = await getApp().resolveOrganizationAddress();
         assert(keys[2].address === addr, 'default secp256k1 keypair should resolve as the organization address');
       });
 
@@ -142,7 +144,7 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
       describe('zkSNARK circuits', () => {
         describe('synchronization', () => {
           before(async () => {
-            circuit = await this.ctx.app.getBaselineCircuit();
+            circuit = await getApp().getBaselineCircuit();
             assert(circuit, 'setup artifacts should not be null');
           });
 
@@ -164,7 +166,7 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
           });
 
           it('should store a reference to the workflow circuit identifier', async () => {
-            assert(this.ctx.app.getWorkflowIdentifier() === circuit.id, 'workflow circuit identifier should have a reference');
+            assert(getApp().getWorkflowIdentifier() === circuit.id, 'workflow circuit identifier should have a reference');
           });
 
           it('should have a copy of the compiled circuit r1cs', async () => {
@@ -187,8 +189,8 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
             let verifier;
 
             before(async () => {
-              shield = this.ctx.app.getWorkgroupContract('shield');
-              verifier = this.ctx.app.getWorkgroupContract('verifier');
+              shield = getApp().getWorkgroupContract('shield');
+              verifier = getApp().getWorkgroupContract('verifier');
             });
 
             it('should reference the deposited workgroup shield contract on-chain', async () => {
@@ -197,7 +199,8 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
             });
 
             it('should track the workgroup shield in an off-chain merkle tree database', async () => {
-              const trackedShieldContracts = await this.ctx.app.baseline.getTracked();
+              // @ts-ignore
+              const trackedShieldContracts = await getApp().baseline.getTracked();
               assert(trackedShieldContracts.indexOf(shield.address.toLowerCase()) !== -1, 'workgroup shield contract should have been tracked');
             });
 
@@ -212,7 +215,7 @@ export const shouldBehaveLikeAWorkgroupOrganization = function () {
   });
 };
 
-export const shouldBehaveLikeAWorkgroupCounterpartyOrganization = function () {
+export const shouldBehaveLikeAWorkgroupCounterpartyOrganization = (getApp: () => ParticipantStack) => () => {
   describe('counterparties', async () => {
     let counterparties;
     let authorizedBearerTokens;
@@ -220,17 +223,17 @@ export const shouldBehaveLikeAWorkgroupCounterpartyOrganization = function () {
     let messagingEndpoint;
 
     before(async () => {
-      counterparties = this.ctx.app.getWorkgroupCounterparties();
-      authorizedBearerTokens = this.ctx.app.getNatsBearerTokens();
-      authorizedBearerToken = await this.ctx.app.resolveNatsBearerToken(counterparties[0]);
-      messagingEndpoint = await this.ctx.app.resolveMessagingEndpoint(counterparties[0]);
-      await this.ctx.app.requireOrganization(await this.ctx.app.resolveOrganizationAddress());
+      counterparties = getApp().getWorkgroupCounterparties();
+      authorizedBearerTokens = getApp().getNatsBearerTokens();
+      authorizedBearerToken = await getApp().resolveNatsBearerToken(counterparties[0]);
+      messagingEndpoint = await getApp().resolveMessagingEndpoint(counterparties[0]);
+      await getApp().requireOrganization(await getApp().resolveOrganizationAddress());
     });
 
     it('should have a local reference to the workgroup counterparties', async () => {
       assert(counterparties, 'workgroup counterparties should not be null');
       assert(counterparties.length === 1, 'workgroup counterparties should not be empty');
-      assert(counterparties[0] !== await this.ctx.app.resolveOrganizationAddress(), 'workgroup counterparties should not contain local org address');
+      assert(counterparties[0] !== await getApp().resolveOrganizationAddress(), 'workgroup counterparties should not contain local org address');
     });
 
     it('should have a local reference to peer-authorized messaging endpoints and associated bearer tokens', async () => {
@@ -248,12 +251,12 @@ export const shouldBehaveLikeAWorkgroupCounterpartyOrganization = function () {
   });
 };
 
-export const shouldBehaveLikeAnInitialWorkgroupOrganization = function () {
+export const shouldBehaveLikeAnInitialWorkgroupOrganization = (getApp: () => ParticipantStack) => () => {
   describe('baseline config', () => {
     let cfg;
 
     before(async () => {
-      cfg = this.ctx.app.getBaselineConfig();
+      cfg = getApp().getBaselineConfig();
     });
 
     it('should have a non-null config', async () => {
@@ -271,7 +274,7 @@ export const shouldBehaveLikeAnInitialWorkgroupOrganization = function () {
     describe('zkSNARK circuits', () => {
       describe('provisioning', () => {
         before(async () => {
-          circuit = await this.ctx.app.deployBaselineCircuit();
+          circuit = await getApp().deployBaselineCircuit();
           assert(circuit, 'setup artifacts should not be null');
         });
 
@@ -293,7 +296,7 @@ export const shouldBehaveLikeAnInitialWorkgroupOrganization = function () {
         });
 
         it('should store a reference to the workflow circuit identifier', async () => {
-          assert(this.ctx.app.getWorkflowIdentifier() === circuit.id, 'workflow circuit identifier should have a reference');
+          assert(getApp().getWorkflowIdentifier() === circuit.id, 'workflow circuit identifier should have a reference');
         });
 
         it('should output the compiled circuit r1cs', async () => {
@@ -316,8 +319,8 @@ export const shouldBehaveLikeAnInitialWorkgroupOrganization = function () {
           let verifier;
 
           before(async () => {
-            shield = this.ctx.app.getWorkgroupContract('shield');
-            verifier = this.ctx.app.getWorkgroupContract('verifier');
+            shield = getApp().getWorkgroupContract('shield');
+            verifier = getApp().getWorkgroupContract('verifier');
           });
 
           it('should deposit the workgroup shield contract on-chain', async () => {
@@ -326,7 +329,8 @@ export const shouldBehaveLikeAnInitialWorkgroupOrganization = function () {
           });
 
           it('should track the workgroup shield in an off-chain merkle tree database', async () => {
-            const trackedShieldContracts = await this.ctx.app.baseline.getTracked();
+            // @ts-ignore
+            const trackedShieldContracts = await getApp().baseline.getTracked(); 
             assert(trackedShieldContracts.indexOf(shield.address.toLowerCase()) !== -1, 'workgroup shield contract should have been tracked');
           });
 
@@ -340,12 +344,12 @@ export const shouldBehaveLikeAnInitialWorkgroupOrganization = function () {
   });
 };
 
-export const shouldBehaveLikeAnInvitedWorkgroupOrganization = function () {
+export const shouldBehaveLikeAnInvitedWorkgroupOrganization = (getApp: () => ParticipantStack) => () => {
   describe('baseline config', () => {
     let cfg;
 
     before(async () => {
-      cfg = this.ctx.app.getBaselineConfig();
+      cfg = getApp().getBaselineConfig();
     });
 
     it('should have a non-null config', async () => {
@@ -362,8 +366,8 @@ export const shouldBehaveLikeAnInvitedWorkgroupOrganization = function () {
     let workgroupToken;
 
     before(async () => {
-      workgroup = this.ctx.app.getWorkgroup();
-      workgroupToken = this.ctx.app.getWorkgroupToken();
+      workgroup = getApp().getWorkgroup();
+      workgroupToken = getApp().getWorkgroupToken();
     });
 
     it('should persist the workgroup in the local registry', async () => {


### PR DESCRIPTION
# Description

Small changes of the BRI-1 Tests
 -  Changed passing of data between `e2e.spec.ts` and `shared.ts`, from context to parameters
 -  Added await for initialization of Alice and Bob in tests (prevents race condition)
 -  Simplified retry of services
 -  Added explicit waiting for zkSNARK circuits sync (prevents race condition)

## Related Issue

No related issue

## Motivation and Context

Because it helps with the tests code quality and prevents some race conditions test fails

## How Has This Been Tested

Tested with debugger and checked for the usefulness of the explicit waiting for solving race conditions

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

