### PR TITLE
Update ethers.js

### DIFF
--- a/examples/radish34/api/src/utils/ethers.js
+++ b/examples/radish34/api/src/utils/ethers.js
@@ -1,13 +1,14 @@
 const { ethers, utils } = require('ethers');
 const { BigNumber } = require('ethers/utils');
 const { logger } = require('radish34-logger');
+import { IBlockchainService} from '@baseline-protocol/api';
 
 let instance = null;
 let networkId = null;
 
 const getProvider = uri => {
   if (instance) return instance;
-  instance = new ethers.providers.JsonRpcProvider(uri);
+  instance = new IBlockchainService.rpcExec(uri);
   return instance;
 };
 


### PR DESCRIPTION
Use baseline-protocol/api IBlockchainService.rpcExec method instead of radish34 api service ethers.providers.JsonRpcProvider method.

# Description

<!--- Describe your changes in detail -->
 Implement json-rpc requests by using @baseline-protocol/api instead of radish34 api service

## Related Issue
Issue #225 

## Motivation and Context

Radish34 was created before the @baseline-protocol nodejs packages were built. It is necessary to update Radish34 using @baseline-protocol since it is released.

## How Has This Been Tested

In ethereum-oasis/baseline/tree/master/examples/radish34/api , run npm install followed by npm test.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
