### PR TITLE
Update maintainers and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # the following owers will be requested for
 # review when someone opens a pull request.
-*       @skarred14 @bitwiseguy @breakpointer @kthomas
+*       @skarred14 @bitwiseguy @kthomas

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,75 +1,79 @@
 # What do maintainers do?
 
 Maintainers are people who take an active role in writing code that advances the Baseline Protocol and/or related projects (e.g. the Radish34 Demo). They are primarily responsible for:
- - Contributing code to the project in the form of PRs that are linked to open and prioritized issues 
- - Reviewing and merging PRs into the master branch
- - Cutting, testing, and releasing new versions of the related Baseline projects
- - Working with the TSC and SSC to advance the Baseline Protocol
 
- They can/should also contribute in the following ways:
- - Writing epics and issues to guide development
- - Setting up and supporting infrastructure (running demos, CI systems, community projects, etc...) that further Baseline
- - Working with the community to help with adoption
- - Presenting the project and key technologies to the public (in-person, webinar, videos, articles, etc...)
- 
+- Contributing code to the project in the form of PRs that are linked to open and prioritized issues
+- Reviewing and merging PRs into the master branch
+- Cutting, testing, and releasing new versions of the related Baseline projects
+- Working with the TSC and SSC to advance the Baseline Protocol
+
+They can/should also contribute in the following ways:
+
+- Writing epics and issues to guide development
+- Setting up and supporting infrastructure (running demos, CI systems, community projects, etc...) that further Baseline
+- Working with the community to help with adoption
+- Presenting the project and key technologies to the public (in-person, webinar, videos, articles, etc...)
 
 # Who are the current maintainers?
 
 Code and Systems maintainers
-  - [Sam Stokes](https://github.com/bitwiseguy) 
-  - [Kartheek Solipuram](https://github.com/skarred14)
-  - [Brian Chamberlain](https://github.com/breakpointer)
-  - [Kyle Thomas](https://github.com/kthomas)
-  - [George Spasov](https://github.com/Perseverance)
-  - [Tomasz Stanczak](https://github.com/tkstanczak)
-  - [Lucas Rodriguez Benitez](https://github.com/LucasRodriguez)
-  - [Anais Ofranc](https://github.com/Consianimis)
-  - [Hamza Tokuchi](https://github.com/Meuko) - [BlockLab](https://www.blocklab.nl/)
+
+- [Sam Stokes](https://github.com/bitwiseguy)
+- [Kartheek Solipuram](https://github.com/skarred14)
+- [Kyle Thomas](https://github.com/kthomas)
+- [Tomasz Stanczak](https://github.com/tkstanczak)
+- [Lucas Rodriguez Benitez](https://github.com/LucasRodriguez)
+- [Anais Ofranc](https://github.com/Consianimis)
+- [Hamza Tokuchi](https://github.com/Meuko) - [BlockLab](https://www.blocklab.nl/)
 
 # How to become a maintainer?
 
 There are two ways to become a maintainer: You are asked by a current maintainer, or you make request to an existing maintainer to become one.
 
-With either path you become a "provisional maintainer". As such you will need to show consistent contributions of code to the project. This can be in the form of pull requests that get merged into master. Or it can be in the form of system architecture and related artifacts that guide the development activities of others. 
+With either path you become a "provisional maintainer". As such you will need to show consistent contributions of code to the project. This can be in the form of pull requests that get merged into master. Or it can be in the form of system architecture and related artifacts that guide the development activities of others.
 
-All provisional maintainers must meet with the existing maintainers and demonstrate they are capable of the following: 
- - Running the project locally
- - Using the testing framework
- - Explaining the components of the system architecture
- - Walking through the code and explain the baseline process
+All provisional maintainers must meet with the existing maintainers and demonstrate they are capable of the following:
+
+- Running the project locally
+- Using the testing framework
+- Explaining the components of the system architecture
+- Walking through the code and explain the baseline process
 
 Once the provisional maintainer demonstrates their capabilities, the existing maintainers will vote during the next scheduled maintainer meeting to give the prospect full maintainer status. Members must vote with 2/3rds majority to add a new maintainer. Voting that results in a tie or potentially other issue will be brought to the TSC for review.
 
 # What is expected of maintainers?
 
 In general, a maintainer needs to:
- - be an expert in one or more fields related to the project
- - show commitment over time with multiple PRs merged
- - be reliable in completing issues to which they have been assigned
- - attend the weekly maintainer meetings (with occasional absences allowed)
- - demonstrate competency in software development
- - follow the project style and testing guidelines
- - have a high degree of understanding of the project architecture
- - be welcoming to others in the community who are using the project
- - contribute in ways that substantially improve the quality of the project and the experience of people who use it
- - follow branch, PR, and code style conventions
+
+- be an expert in one or more fields related to the project
+- show commitment over time with multiple PRs merged
+- be reliable in completing issues to which they have been assigned
+- attend the weekly maintainer meetings (with occasional absences allowed)
+- demonstrate competency in software development
+- follow the project style and testing guidelines
+- have a high degree of understanding of the project architecture
+- be welcoming to others in the community who are using the project
+- contribute in ways that substantially improve the quality of the project and the experience of people who use it
+- follow branch, PR, and code style conventions
 
 # How maintainers organize?
 
-## Slack 
-Maintainers meet and discuss issues virtually via the private #maintainers slack room in the [baseline slack](https://ethereum-baseline.slack.com/). 
+## Slack
+
+Maintainers meet and discuss issues virtually via the private #maintainers slack room in the [baseline slack](https://ethereum-baseline.slack.com/).
 
 ## Weekly Meetings
-There are weekly *Maintainers meetings* where members can discuss plans and issues related to the project, updates, release planning, and other related topics. These meetings are not public but special exceptions can be granted for members of the baseline community, experts, or other key participants. The summaries of the meetings will be posted to the public #maintainer-meeting slack room.
+
+There are weekly _Maintainers meetings_ where members can discuss plans and issues related to the project, updates, release planning, and other related topics. These meetings are not public but special exceptions can be granted for members of the baseline community, experts, or other key participants. The summaries of the meetings will be posted to the public #maintainer-meeting slack room.
 
 # How to stop being a maintainer?
 
-Any of the following ways: 
+Any of the following ways:
 
- - You stop reviewing PR's, responding to messages, answering emails, and/or generally ghost the project.
- - You are disrespectful towards anyone in the community and/or involved in the project.
- - You are disruptive to the general process of maintaining the project, meetings, discussions, issues, or other. 
- - You violate [the code of conduct](./CODE_OF_CONDUCT.md).
- - You notify the other maintainers you would like to relinquish your maintainer status.
- 
+- You stop reviewing PR's, responding to messages, answering emails, and/or generally ghost the project.
+- You are disrespectful towards anyone in the community and/or involved in the project.
+- You are disruptive to the general process of maintaining the project, meetings, discussions, issues, or other.
+- You violate [the code of conduct](./CODE_OF_CONDUCT.md).
+- You notify the other maintainers you would like to relinquish your maintainer status.
+
 Two-thirds of all current maintainers constitute a quorum for a meeting involving a question of removal. A simple majority vote from maintainers attending the meeting is required to remove a maintainer, but the TSC may be brought in to arbitrate if the maintainer to be removed or any other maintainer wishes to dispute the action.


### PR DESCRIPTION
# Description

Remove Brian Chamberlain and George Spasov from the maintainers list because they have decided to reduce their role in the baseline project to focus on other projects in the blockchain space.